### PR TITLE
Bug when sending the new article count to the notify-program

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -839,12 +839,18 @@ void controller::reload_all(bool unattended) {
 	unsigned int unread_feeds2, unread_articles2;
 	compute_unread_numbers(unread_feeds2, unread_articles2);
 	bool notify_always = cfg.get_configvalue_as_bool("notify-always");
-	if (notify_always || unread_feeds2 != unread_feeds || unread_articles2 != unread_articles) {
+	if (notify_always || unread_feeds2 > unread_feeds || unread_articles2 > unread_articles) {
+		int article_count = unread_articles2 - unread_articles;
+		int feed_count = unread_feeds2 - unread_feeds;
+
+		LOG(LOG_DEBUG, "unread article count: %d", article_count);
+		LOG(LOG_DEBUG, "unread feed count: %d", feed_count);
+
 		fmtstr_formatter fmt;
 		fmt.register_fmt('f', utils::to_s(unread_feeds2));
 		fmt.register_fmt('n', utils::to_s(unread_articles2));
-		fmt.register_fmt('d', utils::to_s(unread_articles2 - unread_articles));
-		fmt.register_fmt('D', utils::to_s(unread_feeds2 - unread_feeds));
+		fmt.register_fmt('d', utils::to_s(article_count >= 0 ? article_count : 0));
+		fmt.register_fmt('D', utils::to_s(feed_count >= 0 ? feed_count : 0));
 		this->notify(fmt.do_format(cfg.get_configvalue("notify-format")));
 	}
 }


### PR DESCRIPTION
If the number of unread articles after "reload all" is run is less than the number of unread articles prior to it being run, an error occurs when sending the "new" count to the notify-program.

To reproduce:
1. Hit reload all
2. Mark some articles as read
3. Wait for reload all to finish

The number reported to '%d' (which is new articles in notify-format) is 4294967284, which I guess has like a 0.0000000000001% chance or so of being correct.

This commit will display a 0 if the new article count is less than 0. This is obviously not ideal, but it makes me less crazy than seeing 4294967284 nearly every time newsbeuter reloads.
