### PR TITLE
Query for the Google Reader username if it's not found in the config

### DIFF
--- a/src/google_api.cpp
+++ b/src/google_api.cpp
@@ -44,6 +44,20 @@ static size_t my_write_data(void *buffer, size_t size, size_t nmemb, void *userp
 
 std::string googlereader_api::retrieve_auth() {
 	CURL * handle = curl_easy_init();
+        std::string user = cfg->get_configvalue("googlereader-login");
+        bool flushed = false;
+
+        if (user == "") {
+                std::cout << std::endl;
+                std::cout.flush();
+                flushed = true;
+                std::cout << "Username for Google Reader: ";
+                std::cin >> user;
+                if (user == "") {
+                    return "";
+                }
+        }
+
 	std::string pass = cfg->get_configvalue("googlereader-password");
 	if( pass == "" ) {
 		wordexp_t exp;
@@ -52,8 +66,10 @@ std::string googlereader_api::retrieve_auth() {
 		ifs.open(exp.we_wordv[0]); 
 		wordfree(&exp);
 		if (!ifs) {
-			std::cout << std::endl;
-			std::cout.flush();
+                        if(!flushed) {
+                            std::cout << std::endl;
+                            std::cout.flush();
+                        }
 			// Find a way to do this in C++ by removing cin echoing.
 			pass = std::string( getpass("Password for Google Reader: ") );
 		} else {
@@ -63,7 +79,7 @@ std::string googlereader_api::retrieve_auth() {
 				}
 		}
 	}
-	char * username = curl_easy_escape(handle, cfg->get_configvalue("googlereader-login").c_str(), 0);
+	char * username = curl_easy_escape(handle, user.c_str(), 0);
 	char * password = curl_easy_escape(handle, pass.c_str(), 0);
 
 	std::string postcontent = utils::strprintf("service=reader&Email=%s&Passwd=%s&source=%s/%s&accountType=HOSTED_OR_GOOGLE&continue=http://www.google.com/", 


### PR DESCRIPTION
Added a small change to the `googlereader_api::retrieve_auth` method.

If username for Google Reader isn't found in the config file, `googlereader_api::retrieve_auth` will now ask the user for the username instead of just failing the authentication due to an empty username.
