### PR TITLE
Fix for -q quiet option

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -282,6 +282,8 @@ void controller::run(int argc, char * argv[]) {
 			case 'x':
 				execute_cmds = true;
 				break;
+			case 'q':
+				break;
 			case 'd': // this is an undocumented debug commandline option!
 				GetLogger().set_logfile(optarg);
 				break;


### PR DESCRIPTION
Since newsbeuter 2.5 the -q option, though documented, has not been functional due to an easy mistake in commit 6add15dbc9167976b0855b3467bfdfb45aa91ac3.

This fix makes it behave as expected.
