### PR TITLE
fix make error on OS X

### DIFF
--- a/src/ttrss_api.cpp
+++ b/src/ttrss_api.cpp
@@ -228,7 +228,7 @@ rsspp::feed ttrss_api::fetch_feed(const std::string& id) {
 		const char * link = json_object_get_string(json_object_object_get(item_obj, "link"));
 		const char * content = json_object_get_string(json_object_object_get(item_obj, "content"));
 		time_t updated = (time_t)json_object_get_int(json_object_object_get(item_obj, "updated"));
-		boolean unread = json_object_get_boolean(json_object_object_get(item_obj, "unread"));
+		bool unread = json_object_get_boolean(json_object_object_get(item_obj, "unread"));
 
 		rsspp::item item;
 


### PR DESCRIPTION
I must admit that I don't unterstand C++, but with that patch you can successfully compile newsbeuter using clang and homebrew running OS X Mointain Lion. Here's the [error message](https://github.com/posativ/homebrew-newsbeuter/issues/1#issuecomment-10003573) for:

``` sh
$ cc --version
Apple clang version 4.0 (tags/Apple/clang-421.0.57) (based on LLVM 3.1svn)
```
