### PR TITLE
Update solarized-dark colorscheme, and add solarized-light

### DIFF
--- a/contrib/colorschemes/solarized-dark
+++ b/contrib/colorschemes/solarized-dark
@@ -1,8 +1,17 @@
-# solarized color scheme for newsbeuter <http://www.newsbeuter.org/>
-# more on solarized: http://ethanschoonover.com/solarized
+# Dark solarized color scheme for newsbeuter, based on
+# Ethan Schoonover's Solarized.
+#
+# In order to use this color scheme, you must first configure
+# your terminal emulator to use the Solarized palette.
+# See <http://ethanschoonover.com/solarized/> for more information.
 
-color listnormal color244 color234
-color listfocus  color166 color235 
-color info       color136 color235 
-color background color244 color234
-color article    color244 color234
+color background   default   default
+color listnormal   default   default
+color listfocus    black     yellow
+color info         default   black
+color article      default   default
+
+# highlights
+highlight article "^(Title):.*$" blue default
+highlight article "https?://[^ ]+" red default
+highlight article "\\[image\\ [0-9]+\\]" green default

--- a/contrib/colorschemes/solarized-light
+++ b/contrib/colorschemes/solarized-light
@@ -1,0 +1,17 @@
+# Light Solarized color scheme for newsbeuter, based on
+# Ethan Schoonover's Solarized. 
+#
+# In order to use this color scheme, you must first configure
+# your terminal emulator to use the Solarized palette.
+# See <http://ethanschoonover.com/solarized/> for more information.
+
+color background   default   default
+color listnormal   default   default
+color listfocus    white     yellow
+color info         default   white
+color article      default   default
+
+# highlights
+highlight article "^(Title):.*$" blue default
+highlight article "https?://[^ ]+" red default
+highlight article "\\[image\\ [0-9]+\\]" green default


### PR DESCRIPTION
The current solarized-dark color scheme doesn't work properly on _all_ terminals, and in some cases the colors may show wrong. I fixed that, and made it look a little bit more similar to "[mutt solarized](https://raw.github.com/altercation/solarized/master/img/screen-mutt-dark.png)." I also added a complementing light scheme.