### PR TITLE
Only force redraw if a form action is active.

### DIFF
--- a/src/view.cpp
+++ b/src/view.cpp
@@ -806,9 +806,11 @@ void view::prepare_query_feed(std::tr1::shared_ptr<rss_feed> feed) {
 
 void view::force_redraw() {
 	std::tr1::shared_ptr<formaction> fa = get_current_formaction();
-	fa->set_redraw(true);
-	fa->prepare();
-	fa->get_form()->run(-1);
+	if (fa != NULL) {
+		fa->set_redraw(true);
+		fa->prepare();
+		fa->get_form()->run(-1);
+	}
 }
 
 void view::pop_current_formaction() {


### PR DESCRIPTION
On certain circumstances no form action may be active, for
example if an external browser is used to view news items. If
that happens, get_current_formaction returns a NULL pointer which
is being dereferenced and results in a crash.
