### PR TITLE
Add option to swap title and hints bar.

### DIFF
--- a/doc/configcommands.dsv
+++ b/doc/configcommands.dsv
@@ -71,6 +71,7 @@ show-keymap-hint|[yes/no]|yes|If no, then the keymap hints on the bottom of scre
 show-read-feeds|[yes/no]|yes|If yes, then all feeds, including those without unread articles, are listed. If no, then only feeds with one or more unread articles are list.|show-read-feeds no
 show-read-articles|[yes/no]|yes|If yes, then all articles of a feed are listed in the article list. If no, then only unread articles are listed.|show-read-articles no
 suppress-first-reload|[yes/no]|no|If yes, then the first automatic reload will be suppressed if auto-reload is set to yes.|suppress-first-reload yes
+swap-title-and-hints|[yes/no]|no|If yes, then the title at the top of screen and keymap hints at the bottom of screen will be swapped.|swap-title-and-hints yes
 text-width|<number>|0|If set to a number greater than 0, then all HTML will be rendered to this maximum line length. If set to 0, the terminal width will be used.|text-width 72
 ttrss-flag-publish|<character>|""|If this is set and Tiny Tiny RSS support is used, then all articles that are flagged with the specified flag are being marked as "published" in Tiny Tiny RSS.|ttrss-flag-publish "b"
 ttrss-flag-star|<character>|""|If this is set and Tiny Tiny RSS support is used, then all articles that are flagged with the specified flag are being "starred" in Tiny Tiny RSS.|ttrss-flag-star "a"

--- a/doc/example-config
+++ b/doc/example-config
@@ -272,6 +272,11 @@
 ## parameter syntax: [yes/no]
 # suppress-first-reload no
 
+## configuration option: swap-title-and-hints
+## description: If yes, then the title at the top of screen and keymap hints at the bottom of screen will be swapped.
+## parameter syntax: [yes/no]
+# swap-title-and-hints yes
+
 ## configuration option: text-width
 ## description: If set to a number greater than 0, then all HTML will be rendered to this maximum line length. If set to 0, the terminal width will be used.
 ## parameter syntax: <number>

--- a/src/configcontainer.cpp
+++ b/src/configcontainer.cpp
@@ -77,6 +77,7 @@ configcontainer::configcontainer()
 	config_data["show-read-articles"] = configdata("yes", configdata::BOOL);
 	config_data["goto-next-feed"] = configdata("yes", configdata::BOOL);
 	config_data["display-article-progress"] = configdata("yes", configdata::BOOL);
+	config_data["swap-title-and-hints"] = configdata("no", configdata::BOOL);
 	config_data["show-keymap-hint"] = configdata("yes", configdata::BOOL);
 	config_data["download-timeout"] = configdata("30", configdata::INT);
 	config_data["download-retries"] = configdata("1", configdata::INT);

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -17,6 +17,14 @@ formaction::formaction(view * vv, std::string formstr) : v(vv), f(new stfl::form
 		if (v->get_cfg()->get_configvalue_as_bool("show-keymap-hint") == false) {
 			f->set("showhint", "0");
 		}
+		if (v->get_cfg()->get_configvalue_as_bool("swap-title-and-hints") == true) {
+			std::string hints = f->dump("hints", "", 0);
+			std::string title = f->dump("title", "", 0);
+			f->modify("title", "replace", "label[swap-title]");
+			f->modify("hints", "replace", "label[swap-hints]");
+			f->modify("swap-title", "replace", hints);
+			f->modify("swap-hints", "replace", title);
+		}
 	}
 	valid_cmds.push_back("set");
 	valid_cmds.push_back("quit");

--- a/stfl/dllist.stfl
+++ b/stfl/dllist.stfl
@@ -7,7 +7,7 @@ vbox
   @bind_page_down[bind_page_down]:**
   @bind_home[bind_home]:**
   @bind_end[bind_end]:**
-  label#info
+  label#info[title]
     text[head]:"Queue"
     .expand:h
   !list[dls]
@@ -16,7 +16,7 @@ vbox
     .expand:vh
     pos_name[dlposname]:
     pos[dlpos]:0
-  vbox
+  vbox[hints]
     .expand:0
     .display[showhint]:1
     label#info

--- a/stfl/feedlist.stfl
+++ b/stfl/feedlist.stfl
@@ -7,7 +7,7 @@ vbox
   @bind_page_down[bind_page_down]:**
   @bind_home[bind_home]:**
   @bind_end[bind_end]:**
-  label#info
+  label#info[title]
     text[head]:"Your feeds"
     .expand:h
   !list[feeds]
@@ -16,7 +16,7 @@ vbox
     .expand:vh
     pos_name[feedposname]:
     pos[feedpos]:0
-  vbox
+  vbox[hints]
     .expand:0
     .display[showhint]:1
     label#info

--- a/stfl/filebrowser.stfl
+++ b/stfl/filebrowser.stfl
@@ -7,7 +7,7 @@ vbox
   @bind_page_down[bind_page_down]:**
   @bind_home[bind_home]:**
   @bind_end[bind_end]:**
-  label#info
+  label#info[title]
     text[head]:"File Browser"
     .expand:h
   list[files]
@@ -17,7 +17,7 @@ vbox
     style_focus[listfocus]:fg=yellow,bg=blue,attr=bold
     pos_name[listposname]:
     pos[listpos]:0
-  table
+  table[hints]
     .expand:0 .height:1
     label
       .expand:0

--- a/stfl/help.stfl
+++ b/stfl/help.stfl
@@ -7,7 +7,7 @@ vbox
   @bind_page_down[bind_page_down]:**
   @bind_home[bind_home]:**
   @bind_end[bind_end]:**
-  label#info
+  label#info[title]
     text[head]:"Help"
     .expand:h
   textview[helptext]
@@ -17,7 +17,7 @@ vbox
     style_end[styleend]:fg=blue,attr=bold
     .expand:vh
     offset[helpoffset]:0
-  vbox
+  vbox[hints]
     .expand:0
     .display[showhint]:1
     label#info

--- a/stfl/itemlist.stfl
+++ b/stfl/itemlist.stfl
@@ -7,7 +7,7 @@ vbox
   @bind_page_down[bind_page_down]:**
   @bind_home[bind_home]:**
   @bind_end[bind_end]:**
-  label#info
+  label#info[title]
     text[head]:"Articles for '#'"
     .expand:h
   list[items]
@@ -16,7 +16,7 @@ vbox
     style_focus[listfocus]:fg=yellow,bg=blue,attr=bold
     pos_name[itemposname]:
     pos[itempos]:0
-  vbox
+  vbox[hints]
     .expand:0
     .display[showhint]:1
     label#info

--- a/stfl/itemview.stfl
+++ b/stfl/itemview.stfl
@@ -7,7 +7,7 @@ vbox
   @bind_page_down[bind_page_down]:"** SPACE"
   @bind_home[bind_home]:**
   @bind_end[bind_end]:**
-  label#info
+  label#info[title]
     text[head]:"Article '#'"
     .expand:h
   textview[article]
@@ -16,7 +16,7 @@ vbox
     .expand:vh
     offset[articleoffset]:0
     richtext:1
-  vbox
+  vbox[hints]
     .expand:0
     .display[showhint]:1
     hbox

--- a/stfl/selecttag.stfl
+++ b/stfl/selecttag.stfl
@@ -7,7 +7,7 @@ vbox
   @bind_page_down[bind_page_down]:**
   @bind_home[bind_home]:**
   @bind_end[bind_end]:**
-  label#info
+  label#info[title]
     text[head]:"Select Tag"
     .expand:h
   list[taglist]
@@ -16,7 +16,7 @@ vbox
     style_focus[listfocus]:fg=yellow,bg=blue,attr=bold
     pos_name[tagposname]:
     pos[tagpos]:0
-  vbox
+  vbox[hints]
     .expand:0
     .display[showhint]:1
     label#info

--- a/stfl/urlview.stfl
+++ b/stfl/urlview.stfl
@@ -7,7 +7,7 @@ vbox
   @bind_page_down[bind_page_down]:**
   @bind_home[bind_home]:**
   @bind_end[bind_end]:**
-  label#info
+  label#info[title]
     text[head]:"URLs"
     .expand:h
   !list[urls]
@@ -16,7 +16,7 @@ vbox
     .expand:vh
     pos_name[feedposname]:
     pos[feedpos]:0
-  vbox
+  vbox[hints]
     .expand:0
     .display[showhint]:1
     label#info


### PR DESCRIPTION
With the new option swap-title-and-hints one can swap locations
of title and hint bar. This allows users to further improve
visual similarity to programs like mutt, irssi or weechat.
