### PR TITLE
Add option to colorize unread messages.

### DIFF
--- a/doc/newsbeuter.txt
+++ b/doc/newsbeuter.txt
@@ -181,17 +181,21 @@ Currently, the following elements are supported:
 
 - *listnormal*: a normal list item
 - *listfocus*: the currently selected list item
+- *listnormal_unread*: an unread list item
+- *listfocus_unread*: the currently selected and unread list item
 - *info*: the info bars on top and bottom
 - *background*: the application background
 - *article*: the article text
 
 The default color configuration of newsbeuter looks like this:
 
-	background   white   black
-	listnormal   white   black
-	listfocus    yellow  blue   bold
-	info         yellow  blue   bold
-	article      white   black
+	background          white   black
+	listnormal          white   black
+	listfocus           yellow  blue   bold
+	listnormal_unread   magenta black
+	listfocus_unread    magenta blue   bold
+	info                yellow  blue   bold
+	article             white   black
 
 
 Migrating from other RSS Feed Readers

--- a/src/colormanager.cpp
+++ b/src/colormanager.cpp
@@ -53,7 +53,8 @@ void colormanager::handle_action(const std::string& action, const std::vector<st
 		}
 
 		/* we only allow certain elements to be configured, also to indicate the user possible mis-spellings */
-		if (element == "listnormal" || element == "listfocus" || element == "info" || element == "background" || element == "article") {
+		if (element == "listnormal" || element == "listfocus" || element == "listnormal_unread" || element =="listfocus_unread"
+                || element == "info" || element == "background" || element == "article") {
 			fg_colors[element] = fgcolor;
 			bg_colors[element] = bgcolor;
 			attributes[element] = attribs;

--- a/src/itemlist_formaction.cpp
+++ b/src/itemlist_formaction.cpp
@@ -699,6 +699,10 @@ void itemlist_formaction::prepare() {
 			}
 		}
 
+		if (it->first->unread()) {
+			tmp_itemlist_format = utils::strprintf("<unread>%s</>", itemlist_format.c_str());
+		}
+
 		listfmt.add_line(fmt.do_format(tmp_itemlist_format, width), it->second);
 	}
 

--- a/stfl/itemlist.stfl
+++ b/stfl/itemlist.stfl
@@ -7,11 +7,14 @@ vbox
   @bind_page_down[bind_page_down]:**
   @bind_home[bind_home]:**
   @bind_end[bind_end]:**
+  @style_unread_normal[listnormal_unread]:fg=magenta
+  @style_unread_focus[listfocus_unread]:fg=magenta,bg=blue,attr=bold
   label#info[title]
     text[head]:"Articles for '#'"
     .expand:h
   list[items]
     .expand:vh
+    richtext:1
     style_normal[listnormal]:
     style_focus[listfocus]:fg=yellow,bg=blue,attr=bold
     pos_name[itemposname]:


### PR DESCRIPTION
With listnormal_unread and listfocus_unread two new options have
been added that make it possible to customize colors for unread
articles.
