### PR TITLE
Fix linking of utils::to_string

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -509,6 +509,7 @@ template<class T> std::string utils::to_string(T var) {
 // to avoid linker errors
 template std::string utils::to_string<int>(int var);
 template std::string utils::to_string<unsigned long>(unsigned long var);
+template std::string utils::to_string<unsigned int>(unsigned int var);
 
 std::string utils::absolute_url(const std::string& url, const std::string& link) {
 	xmlChar * newurl = xmlBuildURI((const xmlChar *)link.c_str(), (const xmlChar *)url.c_str());


### PR DESCRIPTION
I've found the following error when compiling head (f8af59e):

```
src/controller.o: In function `newsbeuter::controller::reload_indexes(std::vector<int, std::allocator<int> > const&, bool)':
/home/ivan/build/newsbeuter/src/controller.cpp:790: undefined reference to `std::string newsbeuter::utils::to_string<unsigned int>(unsigned int)'
/home/ivan/build/newsbeuter/src/controller.cpp:791: undefined reference to `std::string newsbeuter::utils::to_string<unsigned int>(unsigned int)'
/home/ivan/build/newsbeuter/src/controller.cpp:792: undefined reference to `std::string newsbeuter::utils::to_string<unsigned int>(unsigned int)'
/home/ivan/build/newsbeuter/src/controller.cpp:793: undefined reference to `std::string newsbeuter::utils::to_string<unsigned int>(unsigned int)'
src/controller.o: In function `newsbeuter::controller::reload_all(bool)':
/home/ivan/build/newsbeuter/src/controller.cpp:915: undefined reference to `std::string   newsbeuter::utils::to_string<unsigned int>(unsigned int)'
src/controller.o:/home/ivan/build/newsbeuter/src/controller.cpp:916: more undefined   references to `std::string newsbeuter::utils::to_string<unsigned int>(unsigned int)' follow
collect2: error: ld returned 1 exit status
make: ** [newsbeuter] Erro 1
```

My system:
- linux 3.8.4
- g++ 4.8.0
- glibc 2.17

Adding an instance of utils::to_string with type unsigned int fixed it.
