### PR TITLE
Allow json-c lib named either "json" or "json-c"

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -99,7 +99,7 @@ check_pkg "sqlite3" || fail "sqlite3"
 check_pkg "libcurl" || check_custom "libcurl" "curl-config" || fail "libcurl"
 check_pkg "libxml-2.0" || check_custom "libxml2" "xml2-config" || fail "libxml2"
 check_pkg "stfl" || fail "stfl"
-check_pkg "json" || fail "json"
+( check_pkg "json" || check_pkg "json-c" ) || fail "json-c"
 
 if [ `uname -s` = "Darwin" ]; then
 	check_custom "ncurses5.4" "ncurses5.4-config" || fail "ncurses5.4"


### PR DESCRIPTION
With version 0.11, the json-c library (https://github.com/json-c/json-c/wiki)
renamed their pkgconfig file from "json" to "json-c".

This way, either name is accepted and the website hinting on failure is
preserved.

See also: https://bugs.gentoo.org/show_bug.cgi?id=467354
