### PR TITLE
Display item titles in podbeuter download listings.

### DIFF
--- a/include/controller.h
+++ b/include/controller.h
@@ -52,7 +52,7 @@ namespace newsbeuter {
 			inline void catchup_all(std::tr1::shared_ptr<rss_feed> feed) { rsscache->catchup_all(feed); }
 			inline bool get_refresh_on_start() const { return refresh_on_start; }
 			bool is_valid_podcast_type(const std::string& mimetype);
-			void enqueue_url(const std::string& url, std::tr1::shared_ptr<rss_feed> feed);
+			void enqueue_url(const std::string& url, const std::string& title, std::tr1::shared_ptr<rss_feed> feed);
 			void notify(const std::string& msg);
 			unsigned int get_pos_of_next_unread(unsigned int pos);
 

--- a/include/download.h
+++ b/include/download.h
@@ -18,6 +18,8 @@ class download {
 		inline dlstatus_t status() const { return dlstatus; }
 		const char * filename();
 		const char * url();
+		const char * title();
+		void set_title(const std::string& str);
 		void set_filename(const std::string& str);
 		void set_url(const std::string& url);
 		void set_progress(double cur, double max);
@@ -32,6 +34,7 @@ class download {
 	private:
 		std::string fn;
 		std::string url_;
+		std::string title_;
 		dlstatus_t dlstatus;
 		float cursize;
 		float totalsize;

--- a/include/queueloader.h
+++ b/include/queueloader.h
@@ -13,6 +13,7 @@ namespace podbeuter {
 			void reload(std::vector<download>& downloads, bool remove_unplayed = false);
 		private:
 			std::string get_filename(const std::string& str);
+			std::string get_title(const std::string& str);
 			std::string queuefile;
 			pb_controller * ctrl;
 	};

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -1193,7 +1193,7 @@ bool controller::is_valid_podcast_type(const std::string& /* mimetype */) {
 	return true;
 }
 
-void controller::enqueue_url(const std::string& url, std::tr1::shared_ptr<rss_feed> feed) {
+void controller::enqueue_url(const std::string& url, const std::string& title, std::tr1::shared_ptr<rss_feed> feed) {
 	bool url_found = false;
 	std::fstream f;
 	f.open(queue_file.c_str(), std::fstream::in);
@@ -1214,7 +1214,7 @@ void controller::enqueue_url(const std::string& url, std::tr1::shared_ptr<rss_fe
 	if (!url_found) {
 		f.open(queue_file.c_str(), std::fstream::app | std::fstream::out);
 		std::string filename = generate_enqueue_filename(url, feed);
-		f << url << " " << stfl::quote(filename) << std::endl;
+		f << url << " " << stfl::quote(filename) << " " << stfl::quote(title) << std::endl;
 		f.close();
 	}
 }
@@ -1438,7 +1438,7 @@ void controller::enqueue_items(std::tr1::shared_ptr<rss_feed> feed) {
 			LOG(LOG_DEBUG, "controller::enqueue_items: enclosure_url = `%s' enclosure_type = `%s'", (*it)->enclosure_url().c_str(), (*it)->enclosure_type().c_str());
 			if (is_valid_podcast_type((*it)->enclosure_type()) && utils::is_http_url((*it)->enclosure_url())) {
 				LOG(LOG_INFO, "controller::enqueue_items: enqueuing `%s'", (*it)->enclosure_url().c_str());
-				enqueue_url((*it)->enclosure_url(), feed);
+				enqueue_url((*it)->enclosure_url(), (*it)->title(), feed);
 				(*it)->set_enqueued(true);
 				rsscache->update_rssitem_unread_and_enqueued(*it, feed->rssurl());
 			}

--- a/src/download.cpp
+++ b/src/download.cpp
@@ -16,6 +16,10 @@ download::download(pb_controller * c) : dlstatus(DL_QUEUED), cursize(0.0), total
 download::~download() {
 }
 
+const char * download::title() {
+	return title_.c_str();
+}
+
 const char * download::filename() {
 	return fn.c_str();
 }
@@ -26,6 +30,10 @@ const char * download::url() {
 
 void download::set_filename(const std::string& str) {
 	fn = str;
+}
+
+void download::set_title(const std::string& str) {
+	title_ = str;
 }
 
 double download::percents_finished() {

--- a/src/itemview_formaction.cpp
+++ b/src/itemview_formaction.cpp
@@ -178,7 +178,7 @@ void itemview_formaction::process_operation(operation op, bool automatic, std::v
 			break;
 		case OP_ENQUEUE: {
 				if (item->enclosure_url().length() > 0 && utils::is_http_url(item->enclosure_url())) {
-					v->get_ctrl()->enqueue_url(item->enclosure_url(), feed);
+					v->get_ctrl()->enqueue_url(item->enclosure_url(), item->title(), feed);
 					v->set_status(utils::strprintf(_("Added %s to download queue."), item->enclosure_url().c_str()));
 				} else {
 					v->set_status(utils::strprintf(_("Invalid URL: '%s'"), item->enclosure_url().c_str()));

--- a/src/pb_view.cpp
+++ b/src/pb_view.cpp
@@ -56,7 +56,7 @@ void pb_view::run(bool auto_download) {
 				unsigned int i = 0;
 				for (std::vector<download>::iterator it=ctrl->downloads().begin();it!=ctrl->downloads().end();++it,++i) {
 					char lbuf[1024];
-					snprintf(lbuf, sizeof(lbuf), " %4u [%6.1fMB/%6.1fMB] [%5.1f %%] [%7.2f kb/s] %-20s %s -> %s", i+1, it->current_size()/(1024*1024), it->total_size()/(1024*1024), it->percents_finished(), it->kbps(), it->status_text(), it->url(), it->filename());
+					snprintf(lbuf, sizeof(lbuf), " %4u [%6.1fMB/%6.1fMB] [%5.1f %%] [%7.2f kb/s] %-15s \"%s\" %s -> %s", i+1, it->current_size()/(1024*1024), it->total_size()/(1024*1024), it->percents_finished(), it->kbps(), it->status_text(), it->title(), it->url(), it->filename());
 					code.append(utils::strprintf("{listitem[%u] text:%s}", i, stfl::quote(lbuf).c_str()));
 				}
 

--- a/src/queueloader.cpp
+++ b/src/queueloader.cpp
@@ -80,17 +80,22 @@ void queueloader::reload(std::vector<download>& downloads, bool remove_unplayed)
 					LOG(LOG_INFO, "queueloader::reload: found `%s' nowhere -> storing to new vector", line.c_str());
 					download d(ctrl);
 					std::string fn;
-					if (fields.size() == 1)
+					std::string title;
+					if (fields.size() == 1) {
 						fn = get_filename(fields[0]);
-					else
+						title = get_title(fields[0]);
+					} else {
 						fn = fields[1];
+						title = fields[2];
+					}
 					d.set_filename(fn);
+					d.set_title(title);
 					if (access(fn.c_str(), F_OK)==0) {
 						LOG(LOG_INFO, "queueloader::reload: found `%s' on file system -> mark as already downloaded", fn.c_str());
-						if (fields.size() >= 3) {
-							if (fields[2] == "downloaded")
+						if (fields.size() >= 4) {
+							if (fields[3] == "downloaded")
 								d.set_status(DL_READY);
-							if (fields[2] == "played")
+							if (fields[3] == "played")
 								d.set_status(DL_PLAYED);
 						}
 						else
@@ -107,7 +112,7 @@ void queueloader::reload(std::vector<download>& downloads, bool remove_unplayed)
 	f.open(queuefile.c_str(), std::fstream::out);
 	if (f.is_open()) {
 		for (std::vector<download>::iterator it=dltemp.begin();it!=dltemp.end();++it) {
-			f << it->url() << " " << stfl::quote(it->filename());
+			f << it->url() << " " << stfl::quote(it->filename()) << " " << stfl::quote(it->title());
 			if (it->status() == DL_READY)
 				f << " downloaded";
 			if (it->status() == DL_PLAYED)
@@ -137,6 +142,13 @@ std::string queueloader::get_filename(const std::string& str) {
 		fn.append(base);
 	}
 	return fn;
+}
+
+std::string queueloader::get_title(const std::string& str) {
+	char buf[1024];
+	snprintf(buf, sizeof(buf), "%s", str.c_str());
+	char * base = basename(buf);
+	return std::string(base);
 }
 
 }

--- a/test/queue
+++ b/test/queue
@@ -1,1 +1,1 @@
-http://testbed.newsbeuter.org/rss20.xml "/home/ak/rss20.xml"
+http://testbed.newsbeuter.org/rss20.xml "/home/ak/rss20.xml" "title"


### PR DESCRIPTION
Queue file format changed to contain additional field for download
titles. This breaks the backwards compatibility with old queue files.
The structure queue entries is now URL PATH TITLE [STATUS]

--

I think displaying episode titles in podbeuter would be an useful improvement, but unfortunately the queue file format isn't really expandable without breaking compatibility with earlier versions. Migrating from old to the new format is a matter of adding one mandatory title field between path and optional status fields. This pull request doesn't include anything to ease the transition so I wouldn't necessarily merge it as it is. Do you think this would be a welcomed change and if so, how should the compatibility issue be handled?

This is just something I hacked together in one evening for my own use and I haven't really tested in thoroughly. It works on my machine...