### PR TITLE
config.sh: missing argument for json-c check

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -105,7 +105,7 @@ check_pkg "sqlite3" || fail "sqlite3"
 check_pkg "libcurl" || check_custom "libcurl" "curl-config" || fail "libcurl"
 check_pkg "libxml-2.0" || check_custom "libxml2" "xml2-config" || fail "libxml2"
 check_pkg "stfl" || fail "stfl"
-( check_pkg "json" "" 0.10 || check_pkg "json-c" 0.10 ) || fail "json-c"
+( check_pkg "json" "" 0.10 || check_pkg "json-c" "" 0.10 ) || fail "json-c"
 
 if [ `uname -s` = "Darwin" ]; then
 	check_custom "ncurses5.4" "ncurses5.4-config" || fail "ncurses5.4"


### PR DESCRIPTION
Therefore config.mk gets an entry like "DEFINES+=0.10" which messes up the compilation process.
