### PR TITLE
JSON-C needs to be 0.11 or higher due to dependency on json_object_iter_*

### DIFF
--- a/README
+++ b/README
@@ -29,7 +29,7 @@ newsbeuter can be compiled.
 - GNU gettext (on systems that don't provide gettext in the libc): ftp://ftp.gnu.org/gnu/gettext/
 - pkg-config: http://pkg-config.freedesktop.org/wiki/
 - libxml2: http://xmlsoft.org/downloads.html
-- json-c: http://oss.metaparadigm.com/json-c/
+- json-c (version 0.11 or newer): https://github.com/json-c/json-c/wiki
 
 Debian unstable comes with ready-to-use packages for these dependencies.
 


### PR DESCRIPTION
JSON-C needs to be 0.11 or higher due to dependency on json_object_iter_\* See http://upstream-tracker.org/compat_reports/json-c/0.10.20120530_to_0.11.20130402/abi_compat_report.html. URL has also changed for homepage of JSON-C
