### PR TITLE
Fix for unbalanced <ol> tags

### DIFF
--- a/src/htmlrenderer.cpp
+++ b/src/htmlrenderer.cpp
@@ -251,7 +251,7 @@ void htmlrenderer::render(std::istream& input, std::vector<std::string>& lines, 
 						add_nonempty_line(curline, tables, lines);
 						prepare_newline(curline,  tables.size() ? 0 : indent_level);
 						indent_level+=2;
-						if (is_ol) {
+						if (is_ol && ol_counts.size() != 0) {
 							curline.append(utils::strprintf("%s.", format_ol_count(ol_counts[ol_counts.size()-1], ol_types[ol_types.size()-1]).c_str()));
 							++ol_counts[ol_counts.size()-1];
 						} else {


### PR DESCRIPTION
The Ubuntu UK podcast feed was crashing newsbeuter. This seems to fix things.

The feed URL is http://feeds.feedburner.com/UbuntuUkPodcastOgg-high?format=xml - I they're on their mid-season break now so it should remain pretty static for a while to test with. The problem seems to be due to the unbalanced ol tags (missing a closing /ol)
