### PR TITLE
Missing var for %s formating of exception message

### DIFF
--- a/src/colormanager.cpp
+++ b/src/colormanager.cpp
@@ -60,7 +60,7 @@ void colormanager::handle_action(const std::string& action, const std::vector<st
 			attributes[element] = attribs;
 			colors_loaded_ = true;
 		} else
-			throw confighandlerexception(utils::strprintf(_("`%s' is not a valid configuration element")));
+			throw confighandlerexception(utils::strprintf(_("`%s' is not a valid configuration element"), element.c_str()));
 
 	} else
 		throw confighandlerexception(AHS_INVALID_COMMAND);


### PR DESCRIPTION
Hi,

Instead of:
```Loading configuration...Error while processing command `color non_element blue white' (/home/digenis/.newsbeuter/config line 1): `non_element' is not a valid configuration element```

I 've been getting:
```Loading configuration...Error while processing command `color non_element blue white' (/home/digenis/.newsbeuter/config line 1): ``%s' is not a valid configuration element' is not a valid configuration element```