### PR TITLE
Fix GCC warning in rss.cpp

### DIFF
--- a/src/rss.cpp
+++ b/src/rss.cpp
@@ -613,7 +613,8 @@ std::string rss_feed::get_status() {
 		case SUCCESS: return " ";
 		case TO_BE_DOWNLOADED: return "_";
 		case DURING_DOWNLOAD: return ".";
-		case DL_ERROR: return "x";
+		case DL_ERROR:
+		default: return "x";
 	}
 }
 


### PR DESCRIPTION
When facing unknown state we should treat this as error.
