### PR TITLE
config.sh: check_pkg: do return instead of exit

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -12,7 +12,7 @@ check_pkg() {
 		if [ -n "$atleast_version" ] ; then
 			if ! pkg-config --atleast-version=$atleast_version ${pkgname} ; then
 				echo "at least ${pkgname} $atleast_version required."
-				exit 1
+				return 1
 			fi
 		fi
 		echo "# configuration for package ${pkgname}" >> config.mk


### PR DESCRIPTION
Fixes json detection case when:
1. the system has "json" package, but too old a version
2. the system has an up-to-date "json-c" version
3. config.sh exits immediately after the first step