### PR TITLE
Already read items still appear in search results as unread

### DIFF
--- a/test/config-search
+++ b/test/config-search
@@ -1,0 +1,1 @@
+show-read-articles yes

--- a/test/test-search.rb
+++ b/test/test-search.rb
@@ -1,0 +1,74 @@
+#!/usr/bin/env ruby
+# script to test searching
+require 'tuitest'
+
+Kernel.system("rm -f cache cache.lock")
+
+Tuitest.init
+verifier = Tuitest::Verifier.new("test-search.rb.log", "RESULT-test-search.rb.xml")
+
+
+if ENV["OFFLINE"] then
+	Tuitest.run("../newsbeuter -c cache -C config-search -u urls-tuitest1-offline")
+else
+	Tuitest.run("../newsbeuter -c cache -C config-search -u urls-tuitest1")
+end
+
+
+Tuitest.wait_until_expected_text(0, 0, "newsbeuter ", 5000)
+Tuitest.keypress("r"[0])
+
+Tuitest.wait_until_idle
+
+Tuitest.keypress("/"[0])
+
+Tuitest.keypress("t"[0])
+Tuitest.keypress("h"[0])
+Tuitest.keypress("i"[0])
+Tuitest.keypress("r"[0])
+Tuitest.keypress("d"[0])
+
+Tuitest.keypress(10)
+Tuitest.wait_until_idle
+
+Tuitest.wait_until_expected_text(0, 0, "newsbeuter ", 5000)
+verifier.expect(1, 3, "1 N  Aug 30   212   |RSS 2.0 testbed f|  RSS 2.0 Item 1")
+verifier.expect(2, 3, "2 N  Aug 28   170   |RSS 2.0 testbed f|  RSS 2.0 Item 3")
+
+# Read the first entry
+Tuitest.keypress(10)
+Tuitest.keypress("q"[0])
+Tuitest.wait_until_idle
+verifier.expect(1, 3, "1    Aug 30   212   |RSS 2.0 testbed f|  RSS 2.0 Item 1")
+verifier.expect(2, 3, "2 N  Aug 28   170   |RSS 2.0 testbed f|  RSS 2.0 Item 3")
+
+# Quit and re-run search
+Tuitest.keypress("q"[0])
+
+Tuitest.keypress("/"[0])
+
+Tuitest.keypress("t"[0])
+Tuitest.keypress("h"[0])
+Tuitest.keypress("i"[0])
+Tuitest.keypress("r"[0])
+Tuitest.keypress("d"[0])
+
+Tuitest.keypress(10)
+Tuitest.wait_until_idle
+
+# The first entry must become invisible because it's already read
+Tuitest.wait_until_expected_text(0, 0, "newsbeuter ", 5000)
+verifier.expect(1, 3, "1    Aug 30   212   |RSS 2.0 testbed f|  RSS 2.0 Item 1")
+verifier.expect(2, 3, "2 N  Aug 28   170   |RSS 2.0 testbed f|  RSS 2.0 Item 3")
+
+Tuitest.keypress("q"[0])
+Tuitest.keypress("q"[0])
+
+Tuitest.wait_until_idle
+
+Tuitest.close
+verifier.finish
+
+Kernel.system("rm -f cache cache.lock")
+
+# EOF


### PR DESCRIPTION
Newsbeuter is pretty and very useful for me, but, unfortunately, it suffers from some small bugs. One of this bugs annoys me very much. It can be reproduced very easily:

 * start a search in an RSS feed
 * read some articles
 * quit search
 * run new search

And voila! You can see your read articles **again**, marked as _unread_, among with other articles that are relevant to the search string.

I tried hard to create working UI test that demonstrates this, and after all, here it is. Here I start a search that finds two articles (31), read one of these articles (39), reset a search (45) and start a new one (56). After that I expect that already read item should not be shown (60). But it is.

Here is a test log:

    I: On (1,3), found `1 N  Aug 30   212   |RSS 2.0 testbed f|  RSS 2.0 Item 1' as expected.
    I: On (1,3), found `1    Aug 30   212   |RSS 2.0 testbed f|  RSS 2.0 Item 1' as expected.
    I: On (2,3), found `2 N  Aug 28   170   |RSS 2.0 testbed f|  RSS 2.0 Item 3' as expected.
    E: On (1,3), expected `1 N  Aug 28   170   |RSS 2.0 testbed f|  RSS 2.0 Item 3', but found `1 N  Aug 30   212   |RSS 2.0 testbed f|  RSS 2.0 Item 1'

Unfortunately, I'm not able to fix this issue yet, but I hope that working test could help identify root cause of this issue, Therefore, I just provide a test at this time. I hope this issue could be fixed!