### PR TITLE
Nonblocking browser open

### DIFF
--- a/src/view.cpp
+++ b/src/view.cpp
@@ -327,7 +327,7 @@ void view::open_in_pager(const std::string& filename) {
 	pop_current_formaction();
 }
 
-oid view::open_in_browser(const std::string& url) {
+void view::open_in_browser(const std::string& url) {
 	formaction_stack.push_back(std::tr1::shared_ptr<formaction>());
 	current_formaction = formaction_stack_size() - 1;
 	std::string cmdline;
@@ -352,8 +352,7 @@ oid view::open_in_browser(const std::string& url) {
 	stfl::reset();
 	LOG(LOG_DEBUG, "view::open_in_browser: running `%s'", cmdline.c_str());
     pid_t pid = fork();
-    if (pid == 0)
-    {
+    if (pid == 0) {
         fclose(stdin);
         fclose(stdout);
 	    ::system(cmdline.c_str());

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -327,7 +327,7 @@ void view::open_in_pager(const std::string& filename) {
 	pop_current_formaction();
 }
 
-void view::open_in_browser(const std::string& url) {
+oid view::open_in_browser(const std::string& url) {
 	formaction_stack.push_back(std::tr1::shared_ptr<formaction>());
 	current_formaction = formaction_stack_size() - 1;
 	std::string cmdline;
@@ -351,7 +351,14 @@ void view::open_in_browser(const std::string& url) {
 	}
 	stfl::reset();
 	LOG(LOG_DEBUG, "view::open_in_browser: running `%s'", cmdline.c_str());
-	::system(cmdline.c_str());
+    pid_t pid = fork();
+    if (pid == 0)
+    {
+        fclose(stdin);
+        fclose(stdout);
+	    ::system(cmdline.c_str());
+        exit(EXIT_SUCCESS);
+    }
 	pop_current_formaction();
 }
 


### PR DESCRIPTION
Hello,

Previously, newsbeuter needed the browser command to be nonblocking (i.e the process had to spawn, fork and the parent process to terminate). However, by default, chromium (it's the only example I had) doesn't fork itself if no instances are alreadyopen. That makes newsbeuter block until chromium is done. I didn't like this behavior, because typically, I open interesting feeds in the browser, to read them more in detail later.
These commits circumvent the problem: a new process is created, and this child process executes whatever the browser command is. That way, we don't assume anything about the browser command and everyone is happy (i.e newsbeuter doesn't block). The child process exits after the browser process exits.

Thanks in advance for your consideration, and sorry for any English errors I might have made, as it's not my mother tongue.

P.S: It might be a good idea to edit the code to replace `system()` by `execvp()`, because system()` is considered "evil".