### PR TITLE
Possible fix for the issue #135

### DIFF
--- a/include/configcontainer.h
+++ b/include/configcontainer.h
@@ -10,8 +10,8 @@ namespace newsbeuter
 struct configdata
 {
 	enum configdata_type { INVALID, BOOL, INT, STR, PATH, ALIAS, ENUM };
-	configdata(const std::string& v = "", configdata_type t = INVALID, bool m = false) : value(v), default_value(v), type(t), multi_option(m) { }
-	configdata(const std::string& v, ...);
+	configdata(const std::string v = "", configdata_type t = INVALID, bool m = false) : value(v), default_value(v), type(t), multi_option(m) { }
+	configdata(const std::string v, ...);
 	std::string value;
 	std::string default_value;
 	configdata_type type;

--- a/src/configcontainer.cpp
+++ b/src/configcontainer.cpp
@@ -16,7 +16,7 @@
 namespace newsbeuter
 {
 
-configdata::configdata(const std::string& v, ...) : value(v), default_value(v), type(ENUM) {
+configdata::configdata(const std::string v, ...) : value(v), default_value(v), type(ENUM) {
 	va_list ap;
 	va_start(ap, v);
 


### PR DESCRIPTION
Macro `va_start` must not be used with reference types, but is actually used with `std::string&`. This change basically replaces passing-by-reference with passing-by-value. It's less optimal than passing by reference but more robust.