### PR TITLE
Prevent cache deletion when one feed is configured

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -561,7 +561,7 @@ void cache::cleanup_cache(std::vector<std::shared_ptr<rss_feed>>& feeds) {
 		for (auto feed : feeds) {
 			std::string name = prepare_query("'%q'",feed->rssurl().c_str());
 			list.append(name);
-			if (i < feed_size-1) {
+			if (i <= feed_size-1) {
 				list.append(", ");
 			}
 		}


### PR DESCRIPTION
When exiting newsbeuter with only one rss feed in `~.newsbeuter/urls`, [src/cache.cpp:568] (https://github.com/akrennmair/newsbeuter/blob/50c713cbc8d7f889dc2029dfc24702ec31fef114/src/cache.cpp#L568) generates a list of one element with extra quotes, which reqults in an SQL statement that looks like this,

```SQL
DELETE FROM rss_feed WHERE rssurl NOT IN ('https://www.archlinux.org/feeds/news/''');
DELETE FROM rss_item WHERE feedurl NOT IN ('https://www.archlinux.org/feeds/news/''');
```

and the extra quotes are messing with the search results,
```
sqlite> select * from rss_feed where rssurl NOT IN ('https://www.archlinux.org/feeds/news/''');
https://www.archlinux.org/feeds/news/|https://www.archlinux.org/news/|Arch Linux: Recent news updates|0|0|
sqlite> select * from rss_feed where rssurl NOT IN ('https://www.archlinux.org/feeds/news/');
sqlite>
```