### PR TITLE
fix example for macro that executes external command via set-browser

### DIFF
--- a/doc/newsbeuter.txt
+++ b/doc/newsbeuter.txt
@@ -712,7 +712,7 @@ something else, such as running an image viewer from the URLs view:
 You can even use this feature to enqueue any of the URLs from the URLs view to
 podbeuter's download queue:
 
-	macro E set browser "echo %u >> ~/.newsbeuter/queue" ; open ; set browser "elinks %u"
+	macro E set browser "echo %u >> ~/.newsbeuter/queue" ; open-in-browser ; set browser "elinks %u"
 
 Commandline Commands
 ~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
this only works if one calls open-in-browser instead of just open