### PR TITLE
Use pkg-config to search for ncursesw.

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -110,6 +110,7 @@ check_pkg "stfl" || fail "stfl"
 if [ `uname -s` = "Darwin" ]; then
 	check_custom "ncurses5.4" "ncurses5.4-config" || fail "ncurses5.4"
 elif [ `uname -s` != "OpenBSD" ]; then
+	check_pkg "ncursesw" || \
 	check_custom "ncursesw5" "ncursesw5-config" ||  fail "ncursesw"
 fi
 check_ssl_implementation


### PR DESCRIPTION
Newsbeuter doesn't recognise new ncurses version when it's hardcoded to specific config program (issue #198). This checks using pkg-config first.