### PR TITLE
Fix feedhq API token URL

### DIFF
--- a/src/feedhq_api.cpp
+++ b/src/feedhq_api.cpp
@@ -233,7 +233,7 @@ std::string feedhq_api::get_new_token() {
 	configure_handle(handle);
 	curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, my_write_data);
 	curl_easy_setopt(handle, CURLOPT_WRITEDATA, &result);
-	curl_easy_setopt(handle, CURLOPT_URL, FEEDHQ_API_TOKEN_URL);
+	curl_easy_setopt(handle, CURLOPT_URL, (cfg->get_configvalue("feedhq-url") + FEEDHQ_API_TOKEN_URL).c_str());
 	curl_easy_perform(handle);
 	curl_easy_cleanup(handle);
 


### PR DESCRIPTION
This fixes a bug where the custom feedhq URL configuration setting
wasn't added for this API call. This resulted in the request to generate
the URL token failing with a `CURLE_URL_MALFORMAT` `CURLcode`. This
stopped calls such as marking an item or all items as read to fail.