### PR TITLE
[On hold] Edit urls remotely

### DIFF
--- a/include/feedhq_api.h
+++ b/include/feedhq_api.h
@@ -34,6 +34,7 @@ class feedhq_urlreader : public urlreader {
 		feedhq_urlreader(configcontainer * c, const std::string& url_file, remote_api * a);
 		virtual ~feedhq_urlreader();
 		virtual void write_config();
+		virtual void dump_urls_to(const std::string& filepath);
 		virtual void reload();
 		virtual std::string get_source();
 	private:

--- a/include/feedhq_api.h
+++ b/include/feedhq_api.h
@@ -17,6 +17,8 @@ class feedhq_api : public remote_api {
 		virtual bool mark_all_read(const std::string& feedurl);
 		virtual bool mark_article_read(const std::string& guid, bool read);
 		virtual bool update_article_flags(const std::string& oldflags, const std::string& newflags, const std::string& guid);
+		virtual bool subscribe_to_feed(const std::string& feedurl);
+		virtual bool unsubscribe_from_feed(const std::string& feedurl);
 		std::vector<std::string> bulk_mark_articles_read(const std::vector<google_replay_pair>& actions);
 	private:
 		std::vector<std::string> get_tags(xmlNode * node);

--- a/include/newsblur_api.h
+++ b/include/newsblur_api.h
@@ -39,6 +39,7 @@ class newsblur_urlreader : public urlreader {
 		newsblur_urlreader(const std::string& url_file, remote_api * a);
 		virtual ~newsblur_urlreader();
 		virtual void write_config();
+		virtual void dump_urls_to(const std::string& filepath);
 		virtual void reload();
 		virtual std::string get_source();
 	private:

--- a/include/newsblur_api.h
+++ b/include/newsblur_api.h
@@ -22,6 +22,8 @@ class newsblur_api : public remote_api {
 		virtual bool mark_all_read(const std::string& feedurl);
 		virtual bool mark_article_read(const std::string& guid, bool read);
 		virtual bool update_article_flags(const std::string& oldflags, const std::string& newflags, const std::string& guid);
+		virtual bool subscribe_to_feed(const std::string& feedurl);
+		virtual bool unsubscribe_from_feed(const std::string& feedurl);
 		rsspp::feed fetch_feed(const std::string& id);
 		// TODO
 	private:

--- a/include/newsblur_api.h
+++ b/include/newsblur_api.h
@@ -26,7 +26,7 @@ class newsblur_api : public remote_api {
 		// TODO
 	private:
 		json_object * query_api(const std::string& url, const std::string* postdata);
-        std::map<std::string, std::vector<std::string>> mk_feeds_to_tags(json_object *);
+		std::map<std::string, std::vector<std::string>> mk_feeds_to_tags(json_object *);
 		std::string auth_info;
 		std::string api_location;
 		feedmap known_feeds;

--- a/include/oldreader_api.h
+++ b/include/oldreader_api.h
@@ -17,6 +17,8 @@ class oldreader_api : public remote_api {
 		virtual bool mark_all_read(const std::string& feedurl);
 		virtual bool mark_article_read(const std::string& guid, bool read);
 		virtual bool update_article_flags(const std::string& oldflags, const std::string& newflags, const std::string& guid);
+		virtual bool subscribe_to_feed(const std::string& feedurl);
+		virtual bool unsubscribe_from_feed(const std::string& feedurl);
 		std::vector<std::string> bulk_mark_articles_read(const std::vector<google_replay_pair>& actions);
 	private:
 		std::vector<std::string> get_tags(xmlNode * node);

--- a/include/oldreader_api.h
+++ b/include/oldreader_api.h
@@ -34,6 +34,7 @@ class oldreader_urlreader : public urlreader {
 		oldreader_urlreader(configcontainer * c, const std::string& url_file, remote_api * a);
 		virtual ~oldreader_urlreader();
 		virtual void write_config();
+		virtual void dump_urls_to(const std::string& filepath);
 		virtual void reload();
 		virtual std::string get_source();
 	private:

--- a/include/remote_api.h
+++ b/include/remote_api.h
@@ -21,6 +21,8 @@ class remote_api {
 		virtual bool mark_all_read(const std::string& feedurl) = 0;
 		virtual bool mark_article_read(const std::string& guid, bool read) = 0;
 		virtual bool update_article_flags(const std::string& oldflags, const std::string& newflags, const std::string& guid) = 0;
+		virtual bool subscribe_to_feed(const std::string& feedurl) = 0;
+		virtual bool unsubscribe_from_feed(const std::string& feedurl) = 0;
 		// TODO
 	protected:
 		configcontainer * cfg;

--- a/include/ttrss_api.h
+++ b/include/ttrss_api.h
@@ -40,6 +40,7 @@ class ttrss_urlreader : public urlreader {
 		ttrss_urlreader(const std::string& url_file, remote_api * a);
 		virtual ~ttrss_urlreader();
 		virtual void write_config();
+		virtual void dump_urls_to(const std::string& filepath);
 		virtual void reload();
 		virtual std::string get_source();
 	private:

--- a/include/ttrss_api.h
+++ b/include/ttrss_api.h
@@ -20,6 +20,8 @@ class ttrss_api : public remote_api {
 		virtual bool mark_all_read(const std::string& feedurl);
 		virtual bool mark_article_read(const std::string& guid, bool read);
 		virtual bool update_article_flags(const std::string& oldflags, const std::string& newflags, const std::string& guid);
+		virtual bool subscribe_to_feed(const std::string& feedurl);
+		virtual bool unsubscribe_from_feed(const std::string& feedurl);
 		rsspp::feed fetch_feed(const std::string& id);
 		bool update_article(const std::string& guid, int mode, int field);
 	private:

--- a/include/urlreader.h
+++ b/include/urlreader.h
@@ -17,6 +17,7 @@ class urlreader {
 		urlreader();
 		virtual ~urlreader();
 		virtual void write_config() = 0;
+		virtual void dump_urls_to(const std::string& filepath) = 0;
 		virtual void reload() = 0;
 		virtual std::string get_source() = 0;
 		std::vector<std::string>& get_urls();
@@ -37,6 +38,7 @@ class file_urlreader : public urlreader {
 		file_urlreader(const std::string& file = "");
 		virtual ~file_urlreader();
 		virtual void write_config();
+		virtual void dump_urls_to(const std::string& filepath);
 		virtual void reload();
 		void load_config(const std::string& file);
 		virtual std::string get_source();
@@ -49,6 +51,7 @@ class opml_urlreader : public urlreader {
 		opml_urlreader(configcontainer * c);
 		virtual ~opml_urlreader();
 		virtual void write_config();
+		virtual void dump_urls_to(const std::string& filepath);
 		virtual void reload();
 		virtual std::string get_source();
 	protected:

--- a/src/feedhq_api.cpp
+++ b/src/feedhq_api.cpp
@@ -314,4 +314,12 @@ std::string feedhq_api::post_content(const std::string& url, const std::string& 
 	return result;
 }
 
+bool feedhq_api::subscribe_to_feed(const std::string& feedurl) {
+	LOG(LOG_ERROR, "feedhq_api::subscribe_to_feed: not implemented");
+}
+
+bool feedhq_api::unsubscribe_from_feed(const std::string& feedurl) {
+	LOG(LOG_ERROR, "feedhq_api::unsubscribe_from_feed: not implemented");
+}
+
 }

--- a/src/feedhq_urlreader.cpp
+++ b/src/feedhq_urlreader.cpp
@@ -11,6 +11,11 @@ void feedhq_urlreader::write_config() {
 	// NOTHING
 }
 
+void feedhq_urlreader::dump_urls_to(const std::string& filepath) {
+	LOG(LOG_ERROR, "feedhq_urlreader::dump_urls_to: not implemented");
+}
+
+
 #define BROADCAST_FRIENDS_URL "http://feedhq.org/reader/atom/user/-/state/com.google/broadcast-friends"
 #define STARRED_ITEMS_URL "http://feedhq.org/reader/atom/user/-/state/com.google/starred"
 #define SHARED_ITEMS_URL "http://feedhq.org/reader/atom/user/-/state/com.google/broadcast"

--- a/src/newsblur_api.cpp
+++ b/src/newsblur_api.cpp
@@ -232,4 +232,12 @@ json_object * newsblur_api::query_api(const std::string& endpoint, const std::st
 	return result;
 }
 
+bool newsblur_api::subscribe_to_feed(const std::string& feedurl) {
+	LOG(LOG_ERROR, "newsblur_api::subscribe_to_feed: not implemented");
+}
+
+bool newsblur_api::unsubscribe_from_feed(const std::string& feedurl) {
+	LOG(LOG_ERROR, "newsblur_api::unsubscribe_from_feed: not implemented");
+}
+
 }

--- a/src/newsblur_api.cpp
+++ b/src/newsblur_api.cpp
@@ -37,16 +37,16 @@ bool newsblur_api::authenticate() {
 std::vector<tagged_feedurl> newsblur_api::get_subscribed_urls() {
 	std::vector<tagged_feedurl> result;
 
-    json_object * response = query_api("/reader/feeds/", NULL);
+	json_object * response = query_api("/reader/feeds/", NULL);
 
 	json_object * feeds = json_object_object_get(response, "feeds");
 
 	json_object_iterator it = json_object_iter_begin(feeds);
 	json_object_iterator itEnd = json_object_iter_end(feeds);
 
-    json_object * folders = json_object_object_get(response, "folders");
+	json_object * folders = json_object_object_get(response, "folders");
 
-    std::map<std::string, std::vector<std::string>> feeds_to_tags = mk_feeds_to_tags(folders);
+	std::map<std::string, std::vector<std::string>> feeds_to_tags = mk_feeds_to_tags(folders);
 
 	while (!json_object_iter_equal(&it, &itEnd)) {
 		const char * feed_id = json_object_iter_peek_name(&it);
@@ -63,7 +63,7 @@ std::vector<tagged_feedurl> newsblur_api::get_subscribed_urls() {
 
 		known_feeds[feed_id] = current_feed;
 
-        std::string std_feed_id(feed_id);
+		std::string std_feed_id(feed_id);
 		std::vector<std::string> tags = feeds_to_tags[std_feed_id];
 		result.push_back(tagged_feedurl(std_feed_id, tags));
 
@@ -75,23 +75,23 @@ std::vector<tagged_feedurl> newsblur_api::get_subscribed_urls() {
 
 std::map<std::string, std::vector<std::string>> newsblur_api::mk_feeds_to_tags(
         json_object * folders) {
-    std::map<std::string, std::vector<std::string>> result;
-    array_list * tags = json_object_get_array(folders);
-    int tags_len = array_list_length(tags);
-    for (int i = 0; i < tags_len; ++i) {
-        json_object * tag_to_feed_ids = json_object_array_get_idx(folders, i);
-        json_object_object_foreach(tag_to_feed_ids, key, feeds_with_tag_obj) {
-            std::string std_key(key);
-            array_list * feeds_with_tag_arr = json_object_get_array(feeds_with_tag_obj);
-            int feeds_with_tag_len = array_list_length(feeds_with_tag_arr);
-            for (int j = 0; j < feeds_with_tag_len; ++j) {
-                json_object * feed_id_obj = json_object_array_get_idx(feeds_with_tag_obj, j);
-                std::string feed_id(json_object_get_string(feed_id_obj));
-                result[feed_id].push_back(std_key);
-            }
-        }
-    }
-    return result;
+	std::map<std::string, std::vector<std::string>> result;
+	array_list * tags = json_object_get_array(folders);
+	int tags_len = array_list_length(tags);
+	for (int i = 0; i < tags_len; ++i) {
+		json_object * tag_to_feed_ids = json_object_array_get_idx(folders, i);
+		json_object_object_foreach(tag_to_feed_ids, key, feeds_with_tag_obj) {
+			std::string std_key(key);
+			array_list * feeds_with_tag_arr = json_object_get_array(feeds_with_tag_obj);
+			int feeds_with_tag_len = array_list_length(feeds_with_tag_arr);
+			for (int j = 0; j < feeds_with_tag_len; ++j) {
+				json_object * feed_id_obj = json_object_array_get_idx(feeds_with_tag_obj, j);
+				std::string feed_id(json_object_get_string(feed_id_obj));
+				result[feed_id].push_back(std_key);
+			}
+		}
+	}
+	return result;
 }
 
 void newsblur_api::configure_handle(CURL * /*handle*/) {
@@ -113,10 +113,10 @@ bool newsblur_api::mark_all_read(const std::string& feed_url) {
 }
 
 bool newsblur_api::mark_article_read(const std::string& guid, bool read) {
-    // handle dummy articles
-    if (guid.empty()) {
-        return false;
-    }
+	// handle dummy articles
+	if (guid.empty()) {
+		return false;
+	}
 	std::string endpoint;
 	int separator = guid.find(ID_SEPARATOR);
 	std::string feed_id = guid.substr(0, separator);

--- a/src/newsblur_urlreader.cpp
+++ b/src/newsblur_urlreader.cpp
@@ -11,6 +11,10 @@ void newsblur_urlreader::write_config() {
 	// NOTHING
 }
 
+void newsblur_urlreader::dump_urls_to(const std::string& filepath) {
+	LOG(LOG_ERROR, "newsblur_urlreader::dump_urls_to: not implemented");
+}
+
 void newsblur_urlreader::reload() {
 	urls.clear();
 	tags.clear();

--- a/src/oldreader_api.cpp
+++ b/src/oldreader_api.cpp
@@ -311,4 +311,12 @@ std::string oldreader_api::post_content(const std::string& url, const std::strin
 	return result;
 }
 
+bool oldreader_api::subscribe_to_feed(const std::string& feedurl) {
+	LOG(LOG_ERROR, "oldreader_api::subscribe_to_feed: not implemented");
+}
+
+bool oldreader_api::unsubscribe_from_feed(const std::string& feedurl) {
+	LOG(LOG_ERROR, "oldreader_api::unsubscribe_from_feed: not implemented");
+}
+
 }

--- a/src/oldreader_urlreader.cpp
+++ b/src/oldreader_urlreader.cpp
@@ -11,6 +11,10 @@ void oldreader_urlreader::write_config() {
 	// NOTHING
 }
 
+void oldreader_urlreader::dump_urls_to(const std::string& filepath) {
+	LOG(LOG_ERROR, "oldreader_urlreader::dump_urls_to: not implemented");
+}
+
 #define BROADCAST_FRIENDS_URL "http://theoldreader.com/reader/atom/user/-/state/com.google/broadcast-friends"
 #define STARRED_ITEMS_URL "http://theoldreader.com/reader/atom/user/-/state/com.google/starred"
 #define SHARED_ITEMS_URL "http://theoldreader.com/reader/atom/user/-/state/com.google/broadcast"

--- a/src/ttrss_api.cpp
+++ b/src/ttrss_api.cpp
@@ -398,5 +398,12 @@ std::string ttrss_api::url_to_id(const std::string& url) {
 	return std::string(pound+1);
 }
 
+bool ttrss_api::subscribe_to_feed(const std::string& feedurl) {
+	LOG(LOG_ERROR, "ttrss_api::subscribe_to_feed: not implemented");
+}
+
+bool ttrss_api::unsubscribe_from_feed(const std::string& feedurl) {
+	LOG(LOG_ERROR, "ttrss_api::unsubscribe_from_feed: not implemented");
+}
 
 }

--- a/src/ttrss_api.cpp
+++ b/src/ttrss_api.cpp
@@ -406,7 +406,19 @@ bool ttrss_api::subscribe_to_feed(const std::string& feedurl) {
 }
 
 bool ttrss_api::unsubscribe_from_feed(const std::string& feedurl) {
-	LOG(LOG_ERROR, "ttrss_api::unsubscribe_from_feed: not implemented");
+	LOG(LOG_INFO, "ttrss_api::unsubscribe_from_feed: unsubscribing from %s",
+	    feedurl.c_str());
+
+	std::map<std::string, std::string> args;
+	std::size_t pos = feedurl.find_last_of("#");
+	args["feed_id"] = feedurl.substr(pos+1);
+	struct json_object * content = run_op("unsubscribeFeed", args);
+
+	if (!content)
+		return false;
+
+	json_object_put(content);
+	return true;
 }
 
 }

--- a/src/ttrss_api.cpp
+++ b/src/ttrss_api.cpp
@@ -402,7 +402,18 @@ std::string ttrss_api::url_to_id(const std::string& url) {
 }
 
 bool ttrss_api::subscribe_to_feed(const std::string& feedurl) {
-	LOG(LOG_ERROR, "ttrss_api::subscribe_to_feed: not implemented");
+	LOG(LOG_INFO, "ttrss_api::subscribe_to_feed: subscribing to %s",
+	    feedurl.c_str());
+
+	std::map<std::string, std::string> args;
+	args["feed_url"] = feedurl;
+	struct json_object * content = run_op("subscribeToFeed", args);
+
+	if (!content)
+		return false;
+
+	json_object_put(content);
+	return true;
 }
 
 bool ttrss_api::unsubscribe_from_feed(const std::string& feedurl) {

--- a/src/ttrss_api.cpp
+++ b/src/ttrss_api.cpp
@@ -353,6 +353,9 @@ void ttrss_api::fetch_feeds_per_category(struct json_object * cat, std::vector<t
 		const char * feed_title = json_object_get_string(json_object_object_get(feed, "title"));
 		const char * feed_url = json_object_get_string(json_object_object_get(feed, "feed_url"));
 
+		// NOTE: controller::edit_urls_file depends on title being the first
+		// tag.
+		// #TagsOrder# (grep it)
 		std::vector<std::string> tags;
 		tags.push_back(std::string("~") + feed_title);
 		if (cat_name) {

--- a/src/ttrss_urlreader.cpp
+++ b/src/ttrss_urlreader.cpp
@@ -11,6 +11,10 @@ void ttrss_urlreader::write_config() {
 	// NOTHING
 }
 
+void ttrss_urlreader::dump_urls_to(const std::string& filepath) {
+    LOG(LOG_ERROR, "ttrss_urlreader::dump_urls_to: not implemented");
+}
+
 void ttrss_urlreader::reload() {
 	urls.clear();
 	tags.clear();

--- a/src/ttrss_urlreader.cpp
+++ b/src/ttrss_urlreader.cpp
@@ -1,6 +1,8 @@
 #include <ttrss_api.h>
 #include <logger.h>
 
+#include <fstream>
+
 namespace newsbeuter {
 
 ttrss_urlreader::ttrss_urlreader(const std::string& url_file, remote_api * a) : file(url_file), api(a) { }
@@ -12,7 +14,19 @@ void ttrss_urlreader::write_config() {
 }
 
 void ttrss_urlreader::dump_urls_to(const std::string& filepath) {
-    LOG(LOG_ERROR, "ttrss_urlreader::dump_urls_to: not implemented");
+	std::fstream file(filepath, std::fstream::out);
+	file << "# TT-RSS API doesn't support editing feed titles and/or categories. We will\n";
+	file << "# still display feed's title (as a comment), but don't expect that adding tags\n";
+	file << "# to URL will do anything.\n";
+	file << "\n";
+
+	for (auto url : urls) {
+		auto title = tags[url][0];
+		file << "# " << title.substr(1) << "\n";
+		file << url << "\n";
+	}
+
+	file.close();
 }
 
 void ttrss_urlreader::reload() {

--- a/src/urlreader.cpp
+++ b/src/urlreader.cpp
@@ -75,8 +75,13 @@ void file_urlreader::load_config(const std::string& file) {
 }
 
 void file_urlreader::write_config() {
+	dump_urls_to(filename);
+}
+
+
+void file_urlreader::dump_urls_to(const std::string& filepath) {
 	std::fstream f;
-	f.open(filename.c_str(),std::fstream::out);
+	f.open(filepath.c_str(),std::fstream::out);
 	if (f.is_open()) {
 		for (auto url : urls) {
 			f << url;
@@ -97,6 +102,11 @@ opml_urlreader::~opml_urlreader() { }
 
 void opml_urlreader::write_config() {
 	// do nothing.
+}
+
+
+void opml_urlreader::dump_urls_to(const std::string& filepath) {
+	LOG(LOG_ERROR, "opml_urlreader::dump_urls_to: not implemented");
 }
 
 


### PR DESCRIPTION
This PR extends existing "edit URLs" functionality to other `urls-source`s (well, almost: at the moment, it's fully implemented only for TT-RSS). So yeah, no need to log into web interface anymore: just press `E` and add/delete feeds as you see fit.

TT-RSS' API doesn't support editing feed's title and category (it doesn't have concept of tags for feeds), so this is absent from urls list.
