### PR TITLE
Apply listnormal_unread and listfocus_unread colors to feedlist

### DIFF
--- a/src/feedlist_formaction.cpp
+++ b/src/feedlist_formaction.cpp
@@ -762,6 +762,7 @@ std::string feedlist_formaction::get_title(std::shared_ptr<rss_feed> feed) {
 std::string feedlist_formaction::format_line(const std::string& feedlist_format, std::shared_ptr<rss_feed> feed, unsigned int pos, unsigned int width) {
 	fmtstr_formatter fmt;
 	unsigned int unread_count = feed->unread_item_count();
+        std::string tmp_feedlist_format = feedlist_format;
 
 	fmt.register_fmt('i', utils::strprintf("%u", pos + 1));
 	fmt.register_fmt('u', utils::strprintf("(%u/%u)",unread_count,static_cast<unsigned int>(feed->items().size())));
@@ -775,7 +776,11 @@ std::string feedlist_formaction::format_line(const std::string& feedlist_format,
 	fmt.register_fmt('L', utils::censor_url(feed->rssurl()));
 	fmt.register_fmt('d', feed->description());
 
-	return fmt.do_format(feedlist_format, width);
+        if (unread_count > 0) {
+          tmp_feedlist_format = utils::strprintf("<unread>%s</>", feedlist_format.c_str());
+        }
+
+	return fmt.do_format(tmp_feedlist_format, width);
 }
 
 std::string feedlist_formaction::title() {

--- a/src/feedlist_formaction.cpp
+++ b/src/feedlist_formaction.cpp
@@ -668,7 +668,7 @@ void feedlist_formaction::set_regexmanager(regexmanager * r) {
 	for (auto attribute : attrs) {
 		attrstr.append(utils::strprintf("@style_%u_normal:%s ", i, attribute.c_str()));
 		attrstr.append(utils::strprintf("@style_%u_focus:%s ", i, attribute.c_str()));
-        i++;
+		i++;
 	}
 	std::string textview = utils::strprintf("{!list[feeds] .expand:vh style_normal[listnormal]: style_focus[listfocus]:fg=yellow,bg=blue,attr=bold pos_name[feedposname]: pos[feedpos]:0 %s richtext:1}", attrstr.c_str());
 	f->modify("feeds", "replace", textview);
@@ -776,10 +776,10 @@ std::string feedlist_formaction::format_line(const std::string& feedlist_format,
 	fmt.register_fmt('L', utils::censor_url(feed->rssurl()));
 	fmt.register_fmt('d', feed->description());
 
-        if (unread_count > 0) {
-          tmp_feedlist_format = utils::strprintf("<unread>%s</>", feedlist_format.c_str());
-        }
-
+	if (unread_count > 0) {
+	  tmp_feedlist_format = utils::strprintf("<unread>%s</>", feedlist_format.c_str());
+	}
+	
 	return fmt.do_format(tmp_feedlist_format, width);
 }
 

--- a/stfl/feedlist.stfl
+++ b/stfl/feedlist.stfl
@@ -7,13 +7,16 @@ vbox
   @bind_page_down[bind_page_down]:**
   @bind_home[bind_home]:**
   @bind_end[bind_end]:**
+  @style_unread_normal[listnormal_unread]:attr=bold
+  @style_unread_focus[listfocus_unread]:fg=yellow,bg=blue,attr=bold
   label#info[title]
     text[head]:"Your feeds"
     .expand:h
   !list[feeds]
+    .expand:vh
+    richtext:1
     style_normal[listnormal]:
     style_focus[listfocus]:fg=yellow,bg=blue,attr=bold
-    .expand:vh
     pos_name[feedposname]:
     pos[feedpos]:0
   vbox[hints]


### PR DESCRIPTION
This allows the use of listnormal_unread and listfocus_unread colors to the feedlist, making it consistent with the itemlist.

If a feed has any unread articles, it applies the listnormal_unread/listfocus_unread. For feeds with no unread articles, listnormal and listfocus are applied as usual.

Thanks!