### PR TITLE
Fix highlight-article priority (Issue #227)

### DIFF
--- a/src/itemlist_formaction.cpp
+++ b/src/itemlist_formaction.cpp
@@ -699,15 +699,16 @@ void itemlist_formaction::prepare() {
 		fmt.register_fmt('a', utils::replace_all(item.first->author(), "<", "<>"));
 		fmt.register_fmt('L', item.first->length());
 
+		tmp_itemlist_format = itemlist_format;
 		if (rxman) {
 			int id;
 			if ((id = rxman->article_matches(item.first.get())) != -1) {
-				tmp_itemlist_format = utils::strprintf("<%d>%s</>", id, itemlist_format.c_str());
+				tmp_itemlist_format = utils::strprintf("<%d>%s</>", id, tmp_itemlist_format.c_str());
 			}
 		}
 
 		if (item.first->unread()) {
-			tmp_itemlist_format = utils::strprintf("<unread>%s</>", itemlist_format.c_str());
+			tmp_itemlist_format = utils::strprintf("<unread>%s</>", tmp_itemlist_format.c_str());
 		}
 
 		listfmt.add_line(fmt.do_format(tmp_itemlist_format, width), item.second);


### PR DESCRIPTION
Highlight-article now takes priority over listnormal_unread and
listfocus_unread.

Fixes issue #227 
