### PR TITLE
fix the one-liner problem

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -53,6 +53,8 @@
 #include <libxml/uri.h>
 #include <curl/curl.h>
 
+#include <stdio.h>
+
 namespace newsbeuter {
 
 #define LOCK_SUFFIX ".lock"
@@ -449,6 +451,7 @@ void controller::run(int argc, char * argv[]) {
 
 
 	std::string type = cfg.get_configvalue("urls-source");
+	std::cout << "Type is " << type << "\n";
 	if (type == "local") {
 		urlcfg = new file_urlreader(url_file);
 	} else if (type == "opml") {
@@ -475,6 +478,7 @@ void controller::run(int argc, char * argv[]) {
 	}
 
 	if (real_offline_mode) {
+	        printf("offline_mode\n");
 		if (!do_export) {
 			std::cout << _("Loading URLs from local cache...");
 			std::cout.flush();
@@ -485,11 +489,13 @@ void controller::run(int argc, char * argv[]) {
 			std::cout << _("done.") << std::endl;
 		}
 	} else {
+	        printf("online mode\n");
 		if (!do_export && !silent) {
-			std::cout << utils::strprintf(_("Loading URLs from %s..."), urlcfg->get_source().c_str());
+			std::cout << utils::strprintf(_("Loading URLs from %s... "), urlcfg->get_source().c_str());
 			std::cout.flush();
 		}
 		if (api) {
+		  printf("api\n");
 			if (!api->authenticate()) {
 				std::cout << "Authentication failed." << std::endl;
 				utils::remove_fs_lock(lock_file);
@@ -530,13 +536,14 @@ void controller::run(int argc, char * argv[]) {
 
 
 	if (do_vacuum) {
-		std::cout << _("done.") << std::endl;
-		std::cout << _("Cleaning up cache thoroughly...");
-		std::cout.flush();
-		rsscache->do_vacuum();
-		std::cout << _("done.") << std::endl;
-		utils::remove_fs_lock(lock_file);
-		return;
+	  printf("do_vacuum\n");
+	  std::cout << _("done.") << std::endl;
+	  std::cout << _("Cleaning up cache thoroughly...");
+	  std::cout.flush();
+	  rsscache->do_vacuum();
+	  std::cout << _("done.") << std::endl;
+	  utils::remove_fs_lock(lock_file);
+	  return;
 	}
 
 	unsigned int i=0;

--- a/src/urlreader.cpp
+++ b/src/urlreader.cpp
@@ -6,6 +6,7 @@
 #include <logger.h>
 #include <sys/utsname.h>
 #include <config.h>
+#include <stdio.h>
 
 namespace newsbeuter {
 
@@ -38,6 +39,7 @@ std::string file_urlreader::get_source() {
 }
 
 void file_urlreader::reload() {
+  printf("reloading...\n");
 	if (offline)
 		return;
 
@@ -48,10 +50,12 @@ void file_urlreader::reload() {
 	std::fstream f;
 	f.open(filename.c_str(),std::fstream::in);
 	if (f.is_open()) {
+	  printf("opening file\n");
 		std::string line;
-		do {
+		while (!f.eof()) {
 			getline(f,line);
-			if (!f.eof() && line.length() > 0 && line[0] != '#') {
+			if (line.length() > 0 && line[0] != '#') {
+			  printf("found line %s\n",line.c_str());
 				std::vector<std::string> tokens = utils::tokenize_quoted(line);
 				if (!tokens.empty()) {
 					std::string url = tokens[0];
@@ -65,7 +69,7 @@ void file_urlreader::reload() {
 					}
 				}
 			}
-		} while (!f.eof());
+		};
 	}
 }
 


### PR DESCRIPTION
When adding items to newsbeuter, you must be careful to add a space afterwords.

This feature fixes that so you don't need to worry about empty space at the end.