### PR TITLE
Fix config handling in rss_parser::download_http

### DIFF
--- a/src/rss_parser.cpp
+++ b/src/rss_parser.cpp
@@ -142,14 +142,14 @@ void rss_parser::retrieve_uri(const std::string& uri) {
 
 void rss_parser::download_http(const std::string& uri) {
 	unsigned int retrycount = cfgcont->get_configvalue_as_int("download-retries");
-	char * proxy = NULL;
-	char * proxy_auth = NULL;
+	std::string proxy;
+	std::string proxy_auth;
 	std::string proxy_type;
 	is_valid = false;
 
 	if (cfgcont->get_configvalue_as_bool("use-proxy") == true) {
-		proxy = const_cast<char *>(cfgcont->get_configvalue("proxy").c_str());
-		proxy_auth = const_cast<char *>(cfgcont->get_configvalue("proxy-auth").c_str());
+		proxy = cfgcont->get_configvalue("proxy");
+		proxy_auth = cfgcont->get_configvalue("proxy-auth");
 		proxy_type = cfgcont->get_configvalue("proxy-type");
 	}
 
@@ -157,7 +157,7 @@ void rss_parser::download_http(const std::string& uri) {
 		try {
 			std::string useragent = utils::get_useragent(cfgcont);
 			LOG(LOG_DEBUG, "rss_parser::download_http: user-agent = %s", useragent.c_str());
-			rsspp::parser p(cfgcont->get_configvalue_as_int("download-timeout"), useragent.c_str(), proxy, proxy_auth, utils::get_proxy_type(proxy_type));
+			rsspp::parser p(cfgcont->get_configvalue_as_int("download-timeout"), useragent.c_str(), proxy.c_str(), proxy_auth.c_str(), utils::get_proxy_type(proxy_type));
 			time_t lm = 0;
 			std::string etag;
 			if (!ign || !ign->matches_lastmodified(uri)) {


### PR DESCRIPTION
The pointer returned by string.c_str becomes invalid after the string is
destroyed. Apparently original code happened to work for options shorter
than ~20 characters.