### PR TITLE
Fix wrapping of article header

### DIFF
--- a/include/htmlrenderer.h
+++ b/include/htmlrenderer.h
@@ -21,7 +21,7 @@ typedef std::pair<std::string,link_type> linkpair;
 
 class htmlrenderer {
 	public:
-		htmlrenderer(unsigned int width = 80, bool raw = false);
+		htmlrenderer(bool raw = false);
 		void render(const std::string&, std::vector<std::string>& lines,  std::vector<linkpair>& links, const std::string& url);
 		void render(std::istream &, std::vector<std::string>& lines, std::vector<linkpair>& links, const std::string& url);
 		// only public for unit testing purposes:

--- a/include/listformatter.h
+++ b/include/listformatter.h
@@ -25,11 +25,13 @@ class listformatter {
 		    unsigned int id = UINT_MAX, unsigned int width = 0);
 		inline void clear() { lines.clear(); }
 		std::string format_list(regexmanager * r = NULL,
-		    const std::string& location = "");
+		    const std::string& location = "",
+			const unsigned int& width = 0);
 		inline unsigned int get_lines_count() {
 			return lines.size();
 		}
 	private:
+		std::vector<std::string> wrap_line(std::string line, unsigned int width);
 		std::vector<line_id_pair> lines;
 		std::string format_cache;
 		bool refresh_cache;

--- a/include/listformatter.h
+++ b/include/listformatter.h
@@ -17,12 +17,10 @@ class listformatter {
 	public:
 		listformatter();
 		~listformatter();
-		void add_line(const std::string& text, unsigned int id = UINT_MAX,
-		    unsigned int width = 0);
-		void add_lines(const std::vector<std::string>& lines,
-		    unsigned int width = 0);
+		void add_line(const std::string& text, unsigned int id = UINT_MAX);
+		void add_lines(const std::vector<std::string>& lines);
 		void set_line(const unsigned int itempos, const std::string& text,
-		    unsigned int id = UINT_MAX, unsigned int width = 0);
+		    unsigned int id = UINT_MAX);
 		inline void clear() { lines.clear(); }
 		std::string format_list(regexmanager * r = NULL,
 		    const std::string& location = "",

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -1408,10 +1408,7 @@ void controller::write_item(std::shared_ptr<rss_item> item, std::ostream& ostr) 
 
 	lines.push_back(std::string(""));
 
-	unsigned int width = cfg.get_configvalue_as_int("text-width");
-	if (width == 0)
-		width = 80;
-	htmlrenderer rnd(width, true);
+	htmlrenderer rnd(true);
 	rnd.render(item->description(), lines, links, item->feedurl());
 
 	for (auto l : lines) {

--- a/src/htmlrenderer.cpp
+++ b/src/htmlrenderer.cpp
@@ -13,7 +13,7 @@
 
 namespace newsbeuter {
 
-htmlrenderer::htmlrenderer(unsigned int width, bool raw) : w(width), raw_(raw) {
+htmlrenderer::htmlrenderer(bool raw) : raw_(raw) {
 	tags["a"] = TAG_A;
 	tags["embed"] = TAG_EMBED;
 	tags["br"] = TAG_BR;
@@ -563,20 +563,8 @@ void htmlrenderer::render(std::istream& input, std::vector<std::string>& lines, 
 					} else {
 						std::vector<std::string> words2 = utils::tokenize_spaced(word);
 						unsigned int i=0;
-						bool new_line = false;
 						for (auto word2 : words2) {
-							if ((utils::strwidth_stfl(curline) + utils::strwidth_stfl(word2)) >= w) {
-								add_nonempty_line(curline, tables, lines);
-								prepare_newline(curline,  tables.size() ? 0 : indent_level);
-								new_line = true;
-							}
-							if (new_line) {
-								if (word2 != " ")
-									curline.append(word2);
-								new_line = false;
-							} else {
-								curline.append(word2);
-							}
+							curline.append(word2);
 							i++;
 						}
 					}
@@ -599,25 +587,12 @@ void htmlrenderer::render(std::istream& input, std::vector<std::string>& lines, 
 					s.erase(0, 1);
 				std::vector<std::string> words = utils::tokenize_spaced(s);
 
-				bool new_line = false;
-
 				if (!line_is_nonempty(curline) && !words.empty() && words[0] == " ") {
 					words.erase(words.begin());
 				}
 
 				for (auto word : words) {
-					if ((utils::strwidth_stfl(curline) + utils::strwidth_stfl(word)) >= w) {
-						add_nonempty_line(curline, tables, lines);
-						prepare_newline(curline, tables.size() ? 0 : indent_level);
-						new_line = true;
-					}
-					if (new_line) {
-						if (word != " ")
-							curline.append(word);
-						new_line = false;
-					} else {
-						curline.append(word);
-					}
+					curline.append(word);
 				}
 			}
 		}

--- a/src/itemview_formaction.cpp
+++ b/src/itemview_formaction.cpp
@@ -79,30 +79,30 @@ void itemview_formaction::prepare() {
 		}
 		if (feedtitle.length() > 0) {
 			feedheader = utils::strprintf("%s%s", _("Feed: "), feedtitle.c_str());
-			listfmt.add_line(feedheader, UINT_MAX, 0);
+			listfmt.add_line(feedheader, UINT_MAX);
 		}
 
 		if (item->title().length() > 0) {
 			std::string title = utils::strprintf("%s%s", _("Title: "), item->title().c_str());
-			listfmt.add_line(title, UINT_MAX, 0);
+			listfmt.add_line(title, UINT_MAX);
 		}
 
 		if (item->author().length() > 0) {
 			std::string author = utils::strprintf("%s%s", _("Author: "), item->author().c_str());
-			listfmt.add_line(author, UINT_MAX, 0);
+			listfmt.add_line(author, UINT_MAX);
 		}
 
 		if (item->link().length() > 0) {
 			std::string link = utils::strprintf("%s%s", _("Link: "), utils::censor_url(item->link()).c_str());
-			listfmt.add_line(link, UINT_MAX, 0);
+			listfmt.add_line(link, UINT_MAX);
 		}
 
 		std::string date = utils::strprintf("%s%s", _("Date: "), item->pubDate().c_str());
-		listfmt.add_line(date, UINT_MAX, 0);
+		listfmt.add_line(date, UINT_MAX);
 
 		if (item->flags().length() > 0) {
 			std::string flags = utils::strprintf("%s%s", _("Flags: "), item->flags().c_str());
-			listfmt.add_line(flags, UINT_MAX, 0);
+			listfmt.add_line(flags, UINT_MAX);
 		}
 
 		if (item->enclosure_url().length() > 0) {
@@ -110,7 +110,7 @@ void itemview_formaction::prepare() {
 			if (item->enclosure_type() != "") {
 				enc_url.append(utils::strprintf(" (%s%s)",  _("type: "), item->enclosure_type().c_str()));
 			}
-			listfmt.add_line(enc_url, UINT_MAX, 0);
+			listfmt.add_line(enc_url, UINT_MAX);
 		}
 
 		listfmt.add_line("");
@@ -129,7 +129,7 @@ void itemview_formaction::prepare() {
 		}
 
 		// listfmt.add_lines(lines, view_width);
-		listfmt.add_lines(lines, 0);
+		listfmt.add_lines(lines);
 
 		num_lines = listfmt.get_lines_count();
 

--- a/src/itemview_formaction.cpp
+++ b/src/itemview_formaction.cpp
@@ -52,14 +52,15 @@ void itemview_formaction::prepare() {
 		}
 
 		std::vector<std::string> lines;
+
 		std::string widthstr = f->get("article:w");
 		unsigned int render_width = 80;
-		unsigned int view_width = 0;
-		if (widthstr.length() > 0) {
-			view_width = render_width = utils::to_u(widthstr);
-			if (render_width - 5 > 0)
-				render_width -= 5;
-		}
+		if (widthstr.length() > 0)
+			render_width = utils::to_u(widthstr);
+		unsigned int text_width = v->get_cfg()->get_configvalue_as_int("text-width");
+		if (text_width < render_width)
+			render_width = text_width;
+
 
 		std::shared_ptr<rss_item> item = feed->get_item_by_guid(guid);
 		listformatter listfmt;
@@ -78,30 +79,30 @@ void itemview_formaction::prepare() {
 		}
 		if (feedtitle.length() > 0) {
 			feedheader = utils::strprintf("%s%s", _("Feed: "), feedtitle.c_str());
-			listfmt.add_line(feedheader, UINT_MAX, view_width);
+			listfmt.add_line(feedheader, UINT_MAX, 0);
 		}
 
 		if (item->title().length() > 0) {
 			std::string title = utils::strprintf("%s%s", _("Title: "), item->title().c_str());
-			listfmt.add_line(title, UINT_MAX, view_width);
+			listfmt.add_line(title, UINT_MAX, 0);
 		}
 
 		if (item->author().length() > 0) {
 			std::string author = utils::strprintf("%s%s", _("Author: "), item->author().c_str());
-			listfmt.add_line(author, UINT_MAX, view_width);
+			listfmt.add_line(author, UINT_MAX, 0);
 		}
 
 		if (item->link().length() > 0) {
 			std::string link = utils::strprintf("%s%s", _("Link: "), utils::censor_url(item->link()).c_str());
-			listfmt.add_line(link, UINT_MAX, view_width);
+			listfmt.add_line(link, UINT_MAX, 0);
 		}
 
 		std::string date = utils::strprintf("%s%s", _("Date: "), item->pubDate().c_str());
-		listfmt.add_line(date, UINT_MAX, view_width);
+		listfmt.add_line(date, UINT_MAX, 0);
 
 		if (item->flags().length() > 0) {
 			std::string flags = utils::strprintf("%s%s", _("Flags: "), item->flags().c_str());
-			listfmt.add_line(flags, UINT_MAX, view_width);
+			listfmt.add_line(flags, UINT_MAX, 0);
 		}
 
 		if (item->enclosure_url().length() > 0) {
@@ -109,7 +110,7 @@ void itemview_formaction::prepare() {
 			if (item->enclosure_type() != "") {
 				enc_url.append(utils::strprintf(" (%s%s)",  _("type: "), item->enclosure_type().c_str()));
 			}
-			listfmt.add_line(enc_url, UINT_MAX, view_width);
+			listfmt.add_line(enc_url, UINT_MAX, 0);
 		}
 
 		listfmt.add_line("");
@@ -120,11 +121,6 @@ void itemview_formaction::prepare() {
 			unread_item_count--;
 		set_head(item->title(), feedtitle, unread_item_count, feed->items().size());
 
-		unsigned int textwidth = v->get_cfg()->get_configvalue_as_int("text-width");
-		if (textwidth > 0) {
-			render_width = textwidth;
-		}
-
 		if (show_source) {
 			render_source(lines, utils::quote_for_stfl(item->description()), render_width);
 		} else {
@@ -132,11 +128,12 @@ void itemview_formaction::prepare() {
 			lines = render_html(item->description(), links, baseurl, render_width);
 		}
 
-		listfmt.add_lines(lines, view_width);
+		// listfmt.add_lines(lines, view_width);
+		listfmt.add_lines(lines, 0);
 
 		num_lines = listfmt.get_lines_count();
 
-		f->modify("article","replace_inner",listfmt.format_list(rxman, "article"));
+		f->modify("article","replace_inner",listfmt.format_list(rxman, "article", render_width));
 		f->set("articleoffset","0");
 
 		if (in_search) {

--- a/src/itemview_formaction.cpp
+++ b/src/itemview_formaction.cpp
@@ -58,7 +58,7 @@ void itemview_formaction::prepare() {
 		if (widthstr.length() > 0)
 			render_width = utils::to_u(widthstr);
 		unsigned int text_width = v->get_cfg()->get_configvalue_as_int("text-width");
-		if (text_width < render_width)
+		if ((text_width != 0) && (text_width < render_width))
 			render_width = text_width;
 
 

--- a/src/listformatter.cpp
+++ b/src/listformatter.cpp
@@ -71,10 +71,7 @@ std::vector<std::string> listformatter::wrap_line(std::string line, unsigned int
 	std::vector<std::string> words = utils::tokenize_spaced(line);
 	std::string subline = "";
 
-	LOG(LOG_DEBUG, "listformatter::wrap_line: '%s'", line.c_str(), line.length(), utils::strwidth_stfl(line));
-
 	for( auto word : words ){
-		LOG(LOG_DEBUG, "listformatter::wrap_line: word:'%s'", word.c_str());
 		unsigned int wlength = utils::strwidth_stfl(word);
 		unsigned int llength = utils::strwidth_stfl(subline);
 
@@ -105,10 +102,6 @@ std::vector<std::string> listformatter::wrap_line(std::string line, unsigned int
 
 	if (subline.length() > 0)
 		lines.push_back(subline);
-
-	for (auto aline : lines) {
-		LOG(LOG_DEBUG, "listformatter::wrap_line: line:'%s'", aline.c_str());
-	}
 
 	return lines;
 }

--- a/src/listformatter.cpp
+++ b/src/listformatter.cpp
@@ -91,6 +91,7 @@ std::string listformatter::format_list(regexmanager * rxman, const std::string& 
 std::vector<std::string> listformatter::wrap_line(std::string line, unsigned int width) {
 	std::vector<std::string> lines;
 	std::string::size_type pos;
+	LOG(LOG_DEBUG, "listformatter::wrap_line: `%s'", line.c_str());
 
 	while (line.length() > width) {
 		unsigned int i = width;
@@ -109,12 +110,16 @@ std::vector<std::string> listformatter::wrap_line(std::string line, unsigned int
 		line.erase(0, i);
 		line.erase(0, line.find_first_not_of(" "));
 		subline.erase(0, subline.find_first_not_of(" "));
-		if(line.length() > 0)
+		if(subline.length() > 0) {
+			LOG(LOG_DEBUG, "listformatter::wrap_line: --> `%s'", subline.c_str());
 			lines.push_back(subline);
+		}
 	}
 
-	if ((line.length() > 0) || (lines.size() == 0))
-		lines.push_back(line);
+	if ((line.length() > 0) || (lines.size() == 0)) {
+			LOG(LOG_DEBUG, "listformatter::wrap_line: --> `%s'", line.c_str());
+			lines.push_back(line);
+	}
 	return lines;
 }
 

--- a/src/listformatter.cpp
+++ b/src/listformatter.cpp
@@ -91,7 +91,6 @@ std::string listformatter::format_list(regexmanager * rxman, const std::string& 
 std::vector<std::string> listformatter::wrap_line(std::string line, unsigned int width) {
 	std::vector<std::string> lines;
 	std::string::size_type pos;
-	LOG(LOG_DEBUG, "listformatter::wrap_line: `%s'", line.c_str());
 
 	while (line.length() > width) {
 		unsigned int i = width;
@@ -111,13 +110,11 @@ std::vector<std::string> listformatter::wrap_line(std::string line, unsigned int
 		line.erase(0, line.find_first_not_of(" "));
 		subline.erase(0, subline.find_first_not_of(" "));
 		if(subline.length() > 0) {
-			LOG(LOG_DEBUG, "listformatter::wrap_line: --> `%s'", subline.c_str());
 			lines.push_back(subline);
 		}
 	}
 
 	if ((line.length() > 0) || (lines.size() == 0)) {
-			LOG(LOG_DEBUG, "listformatter::wrap_line: --> `%s'", line.c_str());
 			lines.push_back(line);
 	}
 	return lines;

--- a/src/rss_parser.cpp
+++ b/src/rss_parser.cpp
@@ -77,7 +77,7 @@ void rss_parser::replace_newline_characters(std::string& str) {
 }
 
 std::string rss_parser::render_xhtml_title(const std::string& title, const std::string& link) {
-	htmlrenderer rnd(1 << 16, true); // a huge number
+	htmlrenderer rnd(true); // a huge number
 	std::vector<std::string> lines;
 	std::vector<linkpair> links; // not needed
 	rnd.render(title, lines, links, link);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -693,8 +693,12 @@ size_t utils::strwidth_stfl(const std::string& str) {
 	if (len > 1) {
 		for (size_t idx=0; idx<len-1; ++idx) {
 			if (str[idx] == '<' && str[idx+1] != '>') {
-				reduce_count += 3;
-				idx += 3;
+				while(str[idx] != '>') {
+					++reduce_count;
+					++idx;
+				}
+				++reduce_count;
+				++idx;
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #264 

To solve this without breaking highlighting of the title, etc, this performs line wrapping in the list formatter so that it can take place after highlighting has occurred.