### PR TITLE
Small corrections.

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -398,7 +398,7 @@ msgstr "diese Hilfe"
 
 #: src/controller.cpp:1033
 #, c-format
-msgid "An error occured while parsing %s."
+msgid "An error occurred while parsing %s."
 msgstr "Ein Fehler ist beim Parsen von %s aufgetreten."
 
 #: src/controller.cpp:1048

--- a/po/es.po
+++ b/po/es.po
@@ -402,7 +402,7 @@ msgstr "esta ayuda"
 
 #: src/controller.cpp:1033
 #, c-format
-msgid "An error occured while parsing %s."
+msgid "An error occurred while parsing %s."
 msgstr "Ocurrió un error al procesar %s."
 
 #: src/controller.cpp:1048

--- a/po/es_ES.po
+++ b/po/es_ES.po
@@ -406,7 +406,7 @@ msgstr "esta ayuda"
 
 #: src/controller.cpp:1033
 #, c-format
-msgid "An error occured while parsing %s."
+msgid "An error occurred while parsing %s."
 msgstr "Se produjo un error analizando %s."
 
 #: src/controller.cpp:1048

--- a/po/fr.po
+++ b/po/fr.po
@@ -398,7 +398,7 @@ msgstr "ce texte d'aide"
 
 #: src/controller.cpp:1033
 #, c-format
-msgid "An error occured while parsing %s."
+msgid "An error occurred while parsing %s."
 msgstr "Une erreur est survenue en analysant %s."
 
 #: src/controller.cpp:1048

--- a/po/hu.po
+++ b/po/hu.po
@@ -400,7 +400,7 @@ msgstr "ez a súgó"
 
 #: src/controller.cpp:1033
 #, c-format
-msgid "An error occured while parsing %s."
+msgid "An error occurred while parsing %s."
 msgstr "Egy hiba lépett fel, miközben %s-t elemeztem."
 
 #: src/controller.cpp:1048

--- a/po/it.po
+++ b/po/it.po
@@ -405,7 +405,7 @@ msgstr "questo aiuto"
 
 #: src/controller.cpp:1033
 #, c-format
-msgid "An error occured while parsing %s."
+msgid "An error occurred while parsing %s."
 msgstr "Si è verificato un errore analizzando %s."
 
 #: src/controller.cpp:1048

--- a/po/ja.po
+++ b/po/ja.po
@@ -380,7 +380,7 @@ msgstr "読んでるよ"
 
 #: src/controller.cpp:1033
 #, c-format
-msgid "An error occured while parsing %s."
+msgid "An error occurred while parsing %s."
 msgstr ""
 
 #: src/controller.cpp:1048

--- a/po/nb.po
+++ b/po/nb.po
@@ -405,7 +405,7 @@ msgstr "denne hjelpen"
 
 #: src/controller.cpp:1033
 #, c-format
-msgid "An error occured while parsing %s."
+msgid "An error occurred while parsing %s."
 msgstr "En feil oppsto under tolkningen av %s"
 
 #: src/controller.cpp:1048

--- a/po/newsbeuter.pot
+++ b/po/newsbeuter.pot
@@ -377,7 +377,7 @@ msgstr ""
 
 #: src/controller.cpp:1033
 #, c-format
-msgid "An error occured while parsing %s."
+msgid "An error occurred while parsing %s."
 msgstr ""
 
 #: src/controller.cpp:1048

--- a/po/nl.po
+++ b/po/nl.po
@@ -404,7 +404,7 @@ msgstr "deze hulptekst"
 
 #: src/controller.cpp:1033
 #, c-format
-msgid "An error occured while parsing %s."
+msgid "An error occurred while parsing %s."
 msgstr "Het ontleden van %s is mislukt."
 
 #: src/controller.cpp:1048

--- a/po/pl.po
+++ b/po/pl.po
@@ -402,7 +402,7 @@ msgstr "ta strona pomocy"
 
 #: src/controller.cpp:1033
 #, c-format
-msgid "An error occured while parsing %s."
+msgid "An error occurred while parsing %s."
 msgstr "Wystąpił błąd podczas przetwarzania %s."
 
 #: src/controller.cpp:1048

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -404,7 +404,7 @@ msgstr "esta ajuda"
 
 #: src/controller.cpp:1033
 #, c-format
-msgid "An error occured while parsing %s."
+msgid "An error occurred while parsing %s."
 msgstr "Um erro ocorreu durante a análise de %s."
 
 #: src/controller.cpp:1048

--- a/po/ru.po
+++ b/po/ru.po
@@ -396,7 +396,7 @@ msgstr "эта помощь"
 
 #: src/controller.cpp:1033
 #, c-format
-msgid "An error occured while parsing %s."
+msgid "An error occurred while parsing %s."
 msgstr "При обработке %s возникла ошибка."
 
 #: src/controller.cpp:1048

--- a/po/sv.po
+++ b/po/sv.po
@@ -404,7 +404,7 @@ msgstr "denna hjälp"
 
 #: src/controller.cpp:1033
 #, c-format
-msgid "An error occured while parsing %s."
+msgid "An error occurred while parsing %s."
 msgstr "Ett fel inträffade vid tolkning av %s."
 
 #: src/controller.cpp:1048

--- a/po/tr.po
+++ b/po/tr.po
@@ -400,7 +400,7 @@ msgstr "bu yardım"
 
 #: src/controller.cpp:1033
 #, c-format
-msgid "An error occured while parsing %s."
+msgid "An error occurred while parsing %s."
 msgstr ""
 
 #: src/controller.cpp:1048

--- a/po/uk.po
+++ b/po/uk.po
@@ -401,7 +401,7 @@ msgstr "ця довідка"
 
 #: src/controller.cpp:1033
 #, c-format
-msgid "An error occured while parsing %s."
+msgid "An error occurred while parsing %s."
 msgstr "Виникла помилка при парсуванні %s"
 
 #: src/controller.cpp:1048

--- a/po/zh.po
+++ b/po/zh.po
@@ -390,7 +390,7 @@ msgstr "该帮助"
 
 #: src/controller.cpp:1033
 #, c-format
-msgid "An error occured while parsing %s."
+msgid "An error occurred while parsing %s."
 msgstr ""
 
 #: src/controller.cpp:1048

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -390,7 +390,7 @@ msgstr "這份說明"
 
 #: src/controller.cpp:1033
 #, c-format
-msgid "An error occured while parsing %s."
+msgid "An error occurred while parsing %s."
 msgstr "在分析%s時發生錯誤"
 
 #: src/controller.cpp:1048

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -405,7 +405,7 @@ void controller::run(int argc, char * argv[]) {
 		cfgparser.parse("/etc/" PROGRAM_NAME "/config");
 		cfgparser.parse(config_file);
 	} catch (const configexception& ex) {
-		LOG(LOG_ERROR,"an exception occured while parsing the configuration file: %s",ex.what());
+		LOG(LOG_ERROR,"an exception occurred while parsing the configuration file: %s",ex.what());
 		std::cout << ex.what() << std::endl;
 		utils::remove_fs_lock(lock_file);
 		return;
@@ -1071,7 +1071,7 @@ void controller::usage(char * argv0) {
 void controller::import_opml(const char * filename) {
 	xmlDoc * doc = xmlReadFile(filename, NULL, 0);
 	if (doc == NULL) {
-		std::cout << utils::strprintf(_("An error occured while parsing %s."), filename) << std::endl;
+		std::cout << utils::strprintf(_("An error occurred while parsing %s."), filename) << std::endl;
 		return;
 	}
 

--- a/src/pb_controller.cpp
+++ b/src/pb_controller.cpp
@@ -152,7 +152,7 @@ void pb_controller::run(int argc, char * argv[]) {
 	static const char getopt_str[] = "C:q:d:l:havV";
 	static const struct option longopts[] = {
 		{"config-file"     , required_argument, 0, 'C'},
-		{"quiet"           , no_argument      , 0, 'q'},
+		{"queue-file"      , required_argument, 0, 'q'},
 		{"log-file"        , required_argument, 0, 'd'},
 		{"log-level"       , required_argument, 0, 'l'},
 		{"help"            , no_argument      , 0, 'h'},

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -328,7 +328,7 @@ void view::open_in_pager(const std::string& filename) {
 		cmdline.append(filename);
 	}
 	stfl::reset();
-	LOG(LOG_DEBUG, "view::open_in_browser: running `%s'", cmdline.c_str());
+	LOG(LOG_DEBUG, "view::open_in_pager: running `%s'", cmdline.c_str());
 	::system(cmdline.c_str());
 	pop_current_formaction();
 }


### PR DESCRIPTION
This PR fixes the following mistakes:
* Corrects a typo (occured -> occurred)
* Corrects the log entry of the open_in_pager function.
* Corrects the long version of the -q podbeuter argument, it should be --queue-file not --quiet.