### PR TITLE
Add options for easily setting the newsbeuter home directory.

### DIFF
--- a/doc/manpage-newsbeuter.txt
+++ b/doc/manpage-newsbeuter.txt
@@ -41,7 +41,7 @@ OPTIONS
 -i opmlfile, --import-from-opml=opmlfile::
        Import an OPML file
 
--H homedir, --homedir homedir::
+-H homedir, --homedir=homedir::
        Use an alternative home directory, individual files can be overridden using -u, -c and -C as described bellow.
 
 -u urlfile, --url-file=urlfile::
@@ -140,7 +140,7 @@ include::chapter-cmdline.txt[]
 ENVIRONMENT
 ----------
 
-'NEWSBEUTERHOME'::
+'NEWSBEUTER_HOME'::
         If set, that directory is used instead of the default.
 
 FILES

--- a/doc/manpage-newsbeuter.txt
+++ b/doc/manpage-newsbeuter.txt
@@ -41,6 +41,9 @@ OPTIONS
 -i opmlfile, --import-from-opml=opmlfile::
        Import an OPML file
 
+-H homedir, --homedir homedir::
+       Use an alternative home directory, individual files can be overridden using -u, -c and -C as described bellow.
+
 -u urlfile, --url-file=urlfile::
        Use an alternative URL file
 
@@ -134,6 +137,11 @@ include::chapter-cmdline.txt[]
 '<number>'::
         Jump to the <number>th entry in the current dialog
 
+ENVIRONMENT
+----------
+
+'NEWSBEUTERHOME'::
+        If set, that directory is used instead of the default.
 
 FILES
 -----

--- a/doc/manpage-newsbeuter.txt
+++ b/doc/manpage-newsbeuter.txt
@@ -41,7 +41,7 @@ OPTIONS
 -i opmlfile, --import-from-opml=opmlfile::
        Import an OPML file
 
--H homedir, --homedir=homedir::
+-H homedir, --home-dir=homedir::
        Use an alternative home directory, individual files can be overridden using -u, -c and -C as described bellow.
 
 -u urlfile, --url-file=urlfile::

--- a/doc/manpage-podbeuter.txt
+++ b/doc/manpage-podbeuter.txt
@@ -25,6 +25,9 @@ OPTIONS
 -h, --help::
         Display help
 
+-H homedir, --homedir homedir::
+       Use an alternative home directory, individual files can be overridden using -C and -q as described bellow.
+
 -C configfile, --config-file=configfile::
        Use an alternative configuration file
 
@@ -53,6 +56,12 @@ CONFIGURATION COMMANDS
 
 include::podbeuter-cfgcmds.txt[]
 
+
+ENVIRONMENT
+----------
+
+'NEWSBEUTERHOME'::
+        If set, that directory is used instead of the default.
 
 FILES
 -----

--- a/doc/manpage-podbeuter.txt
+++ b/doc/manpage-podbeuter.txt
@@ -25,7 +25,7 @@ OPTIONS
 -h, --help::
         Display help
 
--H homedir, --homedir=homedir::
+-H homedir, --home-dir=homedir::
        Use an alternative home directory, individual files can be overridden using -C and -q as described bellow.
 
 -C configfile, --config-file=configfile::

--- a/doc/manpage-podbeuter.txt
+++ b/doc/manpage-podbeuter.txt
@@ -25,7 +25,7 @@ OPTIONS
 -h, --help::
         Display help
 
--H homedir, --homedir homedir::
+-H homedir, --homedir=homedir::
        Use an alternative home directory, individual files can be overridden using -C and -q as described bellow.
 
 -C configfile, --config-file=configfile::
@@ -60,7 +60,7 @@ include::podbeuter-cfgcmds.txt[]
 ENVIRONMENT
 ----------
 
-'NEWSBEUTERHOME'::
+'NEWSBEUTER_HOME'::
         If set, that directory is used instead of the default.
 
 FILES

--- a/include/controller.h
+++ b/include/controller.h
@@ -106,7 +106,7 @@ class controller {
 	private:
 		void usage(char * argv0);
 		bool setup_dirs_xdg(const char *env_home, bool silent);
-		void setup_dirs(bool silent);
+		void setup_dirs(const char *custom_home, bool silent);
 		void version_information(const char * argv0, unsigned int level);
 		void import_opml(const char * filename);
 		void export_opml();

--- a/include/pb_controller.h
+++ b/include/pb_controller.h
@@ -55,6 +55,7 @@ class pb_controller {
 
 	private:
 		bool setup_dirs_xdg(const char *env_home);
+		void setup_dirs(const char *custom_home);
 
 		pb_view * v;
 		std::string config_file;

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -241,7 +241,7 @@ void controller::run(int argc, char * argv[]) {
 	static const struct option longopts[] = {
 		{"cache-file"      , required_argument, 0, 'c'},
 		{"config-file"     , required_argument, 0, 'C'},
-		{"homedir"         , required_argument, 0, 'H'},
+		{"home-dir"        , required_argument, 0, 'H'},
 		{"execute"         , required_argument, 0, 'x'},
 		{"export-to-file"  , required_argument, 0, 'E'},
 		{"export-to-opml"  , no_argument      , 0, 'e'},
@@ -259,8 +259,9 @@ void controller::run(int argc, char * argv[]) {
 		{0                 , 0                , 0,  0 }
 	};
 
-	/* First of all, let's check for options that imply silencing of the
-	 * output: import, export, command execution and, well, quiet mode */
+	/* First, lets check for options that imply output silencing i.e. import,
+	 * export command execution and, well, quiet mode. Additionally, check if a
+	 * custom home directory has been supplied so we can set it up early */
 	char *homedir = NULL;
 	while ((c = ::getopt_long(argc, argv, getopt_str, longopts, NULL)) != -1) {
 		if (strchr("iexq", c) != NULL) {
@@ -273,7 +274,7 @@ void controller::run(int argc, char * argv[]) {
 
 	setup_dirs(homedir, silent);
 
-	/* Now that silencing's set up, let's rewind to the beginning of argv and
+	/* Now that silencing and the home directory's set up, let's rewind to the beginning of argv and
 	 * process the options */
 	optind = 1;
 
@@ -1034,7 +1035,7 @@ void controller::version_information(const char * argv0, unsigned int level) {
 
 void controller::usage(char * argv0) {
 	auto msg =
-	    utils::strprintf(_("%s %s\nusage: %s [-i <file>|-e] [-u <urlfile>] "
+	    utils::strprintf(_("%s %s\nusage: %s [-H <homedir>] [-i <file>|-e] [-u <urlfile>] "
 	    "[-c <cachefile>] [-x <command> ...] [-h]\n"),
 	    PROGRAM_NAME,
 	    PROGRAM_VERSION,
@@ -1052,6 +1053,7 @@ void controller::usage(char * argv0) {
 		{ 'e', "export-to-opml"  , ""                , _s("export OPML feed to stdout") }                                                 ,
 		{ 'r', "refresh-on-start", ""                , _s("refresh feeds on start") }                                                     ,
 		{ 'i', "import-from-opml", _s("<file>")      , _s("import OPML file") }                                                           ,
+		{ 'H', "home-dir"        , _s("<homedir>")   , _s("set the home directory") }                                                     ,
 		{ 'u', "url-file"        , _s("<urlfile>")   , _s("read RSS feed URLs from <urlfile>") }                                          ,
 		{ 'c', "cache-file"      , _s("<cachefile>") , _s("use <cachefile> as cache file") }                                              ,
 		{ 'C', "config-file"     , _s("<configfile>"), _s("read configuration from <configfile>") }                                       ,

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -164,13 +164,13 @@ bool controller::setup_dirs_xdg(const char *env_home, bool silent) {
 
 void controller::setup_dirs(const char *custom_home, bool silent) {
 	const char * env_home;
-	if(custom_home){
+	if (custom_home) {
 		LOG(LOG_INFO, "controller::setup_dirs: Using home directory provided by the command line: %s", custom_home);
 		config_dir = custom_home;
-	}else if((env_home = ::getenv("NEWSBEUTERHOME"))){
-		LOG(LOG_INFO, "controller::setup_dirs: Using home directory provided by the NEWSBEUTERHOME environment variable: %s", env_home);
+	} else if ((env_home = ::getenv("NEWSBEUTER_HOME"))) {
+		LOG(LOG_INFO, "controller::setup_dirs: Using home directory provided by the NEWSBEUTER_HOME environment variable: %s", env_home);
 		config_dir = env_home;
-	}else{
+	} else {
 		if (!(env_home = ::getenv("HOME"))) {
 			struct passwd * spw = ::getpwuid(::getuid());
 			if (spw) {
@@ -266,7 +266,7 @@ void controller::run(int argc, char * argv[]) {
 		if (strchr("iexq", c) != NULL) {
 			silent = true;
 		}
-		if(strchr("H", c) != NULL){
+		if (strchr("H", c) != NULL) {
 			homedir = optarg;
 		}
 	}

--- a/src/pb_controller.cpp
+++ b/src/pb_controller.cpp
@@ -168,7 +168,7 @@ void pb_controller::run(int argc, char * argv[]) {
 	static const struct option longopts[] = {
 		{"config-file"     , required_argument, 0, 'C'},
 		{"queue-file"      , required_argument, 0, 'q'},
-		{"homedir"         , required_argument, 0, 'H'},
+		{"home-dir"        , required_argument, 0, 'H'},
 		{"log-file"        , required_argument, 0, 'd'},
 		{"log-level"       , required_argument, 0, 'l'},
 		{"help"            , no_argument      , 0, 'h'},
@@ -177,10 +177,8 @@ void pb_controller::run(int argc, char * argv[]) {
 		{0                 , 0                , 0,  0 }
 	};
 
-	/*
-	Lets check if there is a homedir argument first so individual files can
-	be properly overridden later.
-	*/
+	/* Lets check if there is a homedir argument first so individual files can
+	 * be properly overridden later. */
 	char *homedir = NULL;
 	while ((c = ::getopt_long(argc, argv, getopt_str, longopts, NULL)) != -1) {
 		if (strchr("H", c) != NULL) {
@@ -302,7 +300,7 @@ void pb_controller::run(int argc, char * argv[]) {
 
 void pb_controller::usage(const char * argv0) {
 	auto msg =
-	    utils::strprintf(_("%s %s\nusage %s [-C <file>] [-q <file>] [-h]\n"),
+	    utils::strprintf(_("%s %s\nusage %s [-H <homedir>] [-C <file>] [-q <file>] [-h]\n"),
 	    "podbeuter",
 	    PROGRAM_VERSION,
 	    argv0);
@@ -316,6 +314,7 @@ void pb_controller::usage(const char * argv0) {
 	};
 
 	static const std::vector<arg> args = {
+		{ 'H', "home-dir"    , _s("<homedir>")   , _s("set the home directory") }                                    ,
 		{ 'C', "config-file" , _s("<configfile>"), _s("read configuration from <configfile>") }                      ,
 		{ 'q', "queue-file"  , _s("<queuefile>") , _s("use <queuefile> as queue file") }                             ,
 		{ 'a', "autodownload", ""                , _s("start download on startup") }                                 ,

--- a/src/pb_controller.cpp
+++ b/src/pb_controller.cpp
@@ -116,13 +116,13 @@ bool pb_controller::setup_dirs_xdg(const char *env_home) {
 
 void pb_controller::setup_dirs(const char *custom_home){
 	char * cfgdir;
-	if(custom_home){
+	if (custom_home) {
 		LOG(LOG_INFO, "pb_controller::setup_dirs: Using home directory provided by the command line: %s", custom_home);
 		config_dir = custom_home;
-	}else if((cfgdir = ::getenv("NEWSBEUTERHOME"))){
-		LOG(LOG_INFO, "pb_controller::setup_dirs: Using home directory provided by the NEWSBEUTERHOME environment variable: %s", cfgdir);
+	} else if ((cfgdir = ::getenv("NEWSBEUTER_HOME"))) {
+		LOG(LOG_INFO, "pb_controller::setup_dirs: Using home directory provided by the NEWSBEUTER_HOME environment variable: %s", cfgdir);
 		config_dir = cfgdir;
-	}else{
+	} else {
 		if (!(cfgdir = ::getenv("HOME"))) {
 			struct passwd * spw = ::getpwuid(::getuid());
 			if (spw) {
@@ -183,7 +183,7 @@ void pb_controller::run(int argc, char * argv[]) {
 	*/
 	char *homedir = NULL;
 	while ((c = ::getopt_long(argc, argv, getopt_str, longopts, NULL)) != -1) {
-		if(strchr("H", c) != NULL){
+		if (strchr("H", c) != NULL) {
 			homedir = optarg;
 			break;
 		}

--- a/src/pb_controller.cpp
+++ b/src/pb_controller.cpp
@@ -147,8 +147,8 @@ void pb_controller::setup_dirs(const char *custom_home){
 	config_file = config_dir + std::string(NEWSBEUTER_PATH_SEP) + config_file;
 	queue_file = config_dir + std::string(NEWSBEUTER_PATH_SEP) + queue_file;
 	lock_file = config_dir + std::string(NEWSBEUTER_PATH_SEP) + lock_file;
-	searchfile = utils::strprintf("%s%shistory.search", config_dir, NEWSBEUTER_PATH_SEP);
-	cmdlinefile = utils::strprintf("%s%shistory.cmdline", config_dir, NEWSBEUTER_PATH_SEP);
+	searchfile = utils::strprintf("%s%shistory.search", config_dir.c_str(), NEWSBEUTER_PATH_SEP);
+	cmdlinefile = utils::strprintf("%s%shistory.cmdline", config_dir.c_str(), NEWSBEUTER_PATH_SEP);
 }
 
 pb_controller::pb_controller() : v(0), config_file("config"), queue_file("queue"), cfg(0), view_update_(true),  max_dls(1), ql(0) {

--- a/src/pb_controller.cpp
+++ b/src/pb_controller.cpp
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -113,30 +114,44 @@ bool pb_controller::setup_dirs_xdg(const char *env_home) {
 	return true;
 }
 
-pb_controller::pb_controller() : v(0), config_file("config"), queue_file("queue"), cfg(0), view_update_(true),  max_dls(1), ql(0) {
+void pb_controller::setup_dirs(const char *custom_home){
 	char * cfgdir;
-	if (!(cfgdir = ::getenv("HOME"))) {
-		struct passwd * spw = ::getpwuid(::getuid());
-		if (spw) {
-			cfgdir = spw->pw_dir;
-		} else {
-			std::cout << _("Fatal error: couldn't determine home directory!") << std::endl;
-			std::cout << utils::strprintf(_("Please set the HOME environment variable or add a valid user for UID %u!"), ::getuid()) << std::endl;
-			::exit(EXIT_FAILURE);
+	if(custom_home){
+		LOG(LOG_INFO, "pb_controller::setup_dirs: Using home directory provided by the command line: %s", custom_home);
+		config_dir = custom_home;
+	}else if((cfgdir = ::getenv("NEWSBEUTERHOME"))){
+		LOG(LOG_INFO, "pb_controller::setup_dirs: Using home directory provided by the NEWSBEUTERHOME environment variable: %s", cfgdir);
+		config_dir = cfgdir;
+	}else{
+		if (!(cfgdir = ::getenv("HOME"))) {
+			struct passwd * spw = ::getpwuid(::getuid());
+			if (spw) {
+				cfgdir = spw->pw_dir;
+			} else {
+				std::cout << _("Fatal error: couldn't determine home directory!") << std::endl;
+				std::cout << utils::strprintf(_("Please set the HOME environment variable or add a valid user for UID %u!"), ::getuid()) << std::endl;
+				::exit(EXIT_FAILURE);
+			}
 		}
+		config_dir = cfgdir;
+
+		if (setup_dirs_xdg(cfgdir))
+			return;
+
+		config_dir.append(NEWSBEUTER_PATH_SEP);
+		config_dir.append(NEWSBEUTER_CONFIG_SUBDIR);
 	}
-	config_dir = cfgdir;
 
-	if (setup_dirs_xdg(cfgdir))
-		return;
-
-	config_dir.append(NEWSBEUTER_PATH_SEP);
-	config_dir.append(NEWSBEUTER_CONFIG_SUBDIR);
 	::mkdir(config_dir.c_str(),0700); // create configuration directory if it doesn't exist
 
 	config_file = config_dir + std::string(NEWSBEUTER_PATH_SEP) + config_file;
 	queue_file = config_dir + std::string(NEWSBEUTER_PATH_SEP) + queue_file;
 	lock_file = config_dir + std::string(NEWSBEUTER_PATH_SEP) + lock_file;
+	searchfile = utils::strprintf("%s%shistory.search", config_dir, NEWSBEUTER_PATH_SEP);
+	cmdlinefile = utils::strprintf("%s%shistory.cmdline", config_dir, NEWSBEUTER_PATH_SEP);
+}
+
+pb_controller::pb_controller() : v(0), config_file("config"), queue_file("queue"), cfg(0), view_update_(true),  max_dls(1), ql(0) {
 }
 
 pb_controller::~pb_controller() {
@@ -149,10 +164,11 @@ void pb_controller::run(int argc, char * argv[]) {
 
 	::signal(SIGINT, ctrl_c_action);
 
-	static const char getopt_str[] = "C:q:d:l:havV";
+	static const char getopt_str[] = "C:q:H:d:l:havV";
 	static const struct option longopts[] = {
 		{"config-file"     , required_argument, 0, 'C'},
 		{"queue-file"      , required_argument, 0, 'q'},
+		{"homedir"         , required_argument, 0, 'H'},
 		{"log-file"        , required_argument, 0, 'd'},
 		{"log-level"       , required_argument, 0, 'l'},
 		{"help"            , no_argument      , 0, 'h'},
@@ -160,6 +176,22 @@ void pb_controller::run(int argc, char * argv[]) {
 		{"version"         , no_argument      , 0, 'v'},
 		{0                 , 0                , 0,  0 }
 	};
+
+	/*
+	Lets check if there is a homedir argument first so individual files can
+	be properly overridden later.
+	*/
+	char *homedir = NULL;
+	while ((c = ::getopt_long(argc, argv, getopt_str, longopts, NULL)) != -1) {
+		if(strchr("H", c) != NULL){
+			homedir = optarg;
+			break;
+		}
+	}
+
+	setup_dirs(homedir);
+
+	optind = 1;
 
 	while ((c = ::getopt_long(argc, argv, getopt_str, longopts, NULL)) != -1) {
 		switch (c) {
@@ -173,6 +205,8 @@ void pb_controller::run(int argc, char * argv[]) {
 		case 'q':
 			queue_file = optarg;
 			break;
+		case 'H':
+			break; //Homedir processing was done earlier.
 		case 'a':
 			automatic_dl = true;
 			break;


### PR DESCRIPTION
This PR makes running multiple seperate instances of newsbeuter easier by adding the --homedir command line argument and NEWSBEUTERHOME environment variable to control the newsbeuter config directories.
See the commit message for more details:
> The only way to change home directories until now were the -u -c and -C
> arguments, and even with these you weren't able to change the history files.
> This commit implements the --homedir argument which switches all files to the
> directory provided. Additionally it adds support for the NEWSBEUTERHOME
> environment variable that behaves exactly as --homedir.
> 
> With this commit newsbeuter will look for its files in this order:
> 
> -u -c and -C arguments > --homedir > NEWSBEUTERHOME variable > XDG directories > $HOME/.newsbeuter