### PR TITLE
Set up cache for items in the search result

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -503,6 +503,9 @@ std::vector<std::shared_ptr<rss_item>> cache::search_for_items(const std::string
 	LOG(LOG_DEBUG,"running query: %s",query.c_str());
 
 	rc = sqlite3_exec(db,query.c_str(),search_item_callback,&items,NULL);
+	for (auto item: items) {
+		item->set_cache(this);
+	}
 	if (rc != SQLITE_OK) {
 		LOG(LOG_CRITICAL,"query \"%s\" failed: error = %d", query.c_str(), rc);
 		throw dbexception(db);

--- a/test/cache.cpp
+++ b/test/cache.cpp
@@ -1,0 +1,44 @@
+#include "catch.hpp"
+
+#include <cache.h>
+#include <configcontainer.h>
+#include <rss_parser.h>
+
+#include <unistd.h>
+
+using namespace newsbeuter;
+
+TEST_CASE("cache behaves correctly") {
+	configcontainer * cfg = new configcontainer();
+	cache * rsscache = new cache("test-cache.db", cfg);
+	rss_parser parser("file://data/rss.xml", rsscache, cfg, NULL);
+	std::shared_ptr<rss_feed> feed = parser.parse();
+	REQUIRE(feed->items().size() == 8);
+	rsscache->externalize_rssfeed(feed, false);
+
+	SECTION("items in search result are marked as read") {
+		auto search_items = rsscache->search_for_items("Botox", "");
+		REQUIRE(search_items.size() == 1);
+		auto item = search_items.front();
+		REQUIRE(true == item->unread());
+
+		item->set_unread(false);
+		search_items.clear();
+
+		search_items = rsscache->search_for_items("Botox", "");
+		REQUIRE(search_items.size() == 1);
+		auto updatedItem = search_items.front();
+		REQUIRE(false == updatedItem->unread());
+	}
+
+	std::vector<std::shared_ptr<rss_feed>> feedv;
+	feedv.push_back(feed);
+
+	cfg->set_configvalue("cleanup-on-quit", "true");
+	rsscache->cleanup_cache(feedv);
+
+	delete rsscache;
+	delete cfg;
+
+	::unlink("test-cache.db");
+}


### PR DESCRIPTION
The original attempt to fix the bug with read/unread status (#137) was quite far from the good solution, so I've decided to rewrite it from scratch.

I'm looking forward for feedback, especially on the test. I had very little C++ practice during several past years so there might be stupid errors in the code.