### PR TITLE
Allow searching in query feeds

### DIFF
--- a/include/controller.h
+++ b/include/controller.h
@@ -39,7 +39,7 @@ class controller {
 
 		std::shared_ptr<rss_feed> get_feed(unsigned int pos);
 		std::shared_ptr<rss_feed> get_feed_by_url(const std::string& feedurl);
-		std::vector<std::shared_ptr<rss_item>> search_for_items(const std::string& query, const std::string& feedurl);
+		std::vector<std::shared_ptr<rss_item>> search_for_items(const std::string& query, std::shared_ptr<rss_feed> feed);
 		inline unsigned int get_feedcount() {
 			return feeds.size();
 		}

--- a/include/rss.h
+++ b/include/rss.h
@@ -48,6 +48,10 @@ class rss_item : public matchable {
 			return description_;
 		}
 		void set_description(const std::string& d);
+
+		inline unsigned int size() const {
+			return size_;
+		}
 		void set_size(unsigned int size);
 
 		std::string length() const;

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -489,6 +489,7 @@ std::shared_ptr<rss_feed> cache::internalize_rssfeed(std::string rssurl, rss_ign
 }
 
 std::vector<std::shared_ptr<rss_item>> cache::search_for_items(const std::string& querystr, const std::string& feedurl) {
+	assert(feedurl.substr(0,6) != "query:");
 	std::string query;
 	std::vector<std::shared_ptr<rss_item>> items;
 	int rc;

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -1209,8 +1209,7 @@ std::vector<std::shared_ptr<rss_item>> controller::search_for_items(const std::s
 	LOG(LOG_DEBUG, "controller::search_for_items: setting feed pointers");
 	if(feed != NULL && feed->rssurl().substr(0,6) == "query:") {
 		for (auto item : feed->items()) {
-			if((item->title().find(query) != std::string::npos || item->description().find(query) != std::string::npos)
-					&& !item->deleted()){
+			if(!item->deleted() && (item->title().find(query) != std::string::npos || item->description().find(query) != std::string::npos)){
 				std::shared_ptr<rss_item> newitem(new rss_item(NULL));
 				newitem->set_guid(item->guid());
 				newitem->set_title(item->title());

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -1204,11 +1204,20 @@ void controller::rec_find_rss_outlines(xmlNode * node, std::string tag) {
 
 
 
-std::vector<std::shared_ptr<rss_item>> controller::search_for_items(const std::string& query, const std::string& feedurl) {
-	std::vector<std::shared_ptr<rss_item>> items = rsscache->search_for_items(query, feedurl);
+std::vector<std::shared_ptr<rss_item>> controller::search_for_items(const std::string& query, std::shared_ptr<rss_feed> feed) {
+	std::vector<std::shared_ptr<rss_item>> items;
 	LOG(LOG_DEBUG, "controller::search_for_items: setting feed pointers");
-	for (auto item : items) {
-		item->set_feedptr(get_feed_by_url(item->feedurl()));
+	if(feed != NULL && feed->rssurl().substr(0,6) == "query:") {
+		for (auto item : feed->items()) {
+			if(item->title().find(query) != std::string::npos || item->description().find(query) != std::string::npos){
+				items.push_back(item);
+			}
+		}
+	} else {
+		items = rsscache->search_for_items(query, (feed != NULL ? feed->rssurl() : ""));
+		for (auto item : items) {
+			item->set_feedptr(get_feed_by_url(item->feedurl()));
+		}
 	}
 	return items;
 }

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -1209,7 +1209,8 @@ std::vector<std::shared_ptr<rss_item>> controller::search_for_items(const std::s
 	LOG(LOG_DEBUG, "controller::search_for_items: setting feed pointers");
 	if(feed != NULL && feed->rssurl().substr(0,6) == "query:") {
 		for (auto item : feed->items()) {
-			if(item->title().find(query) != std::string::npos || item->description().find(query) != std::string::npos){
+			if((item->title().find(query) != std::string::npos || item->description().find(query) != std::string::npos)
+					&& !item->deleted()){
 				items.push_back(item);
 			}
 		}

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -1211,7 +1211,28 @@ std::vector<std::shared_ptr<rss_item>> controller::search_for_items(const std::s
 		for (auto item : feed->items()) {
 			if((item->title().find(query) != std::string::npos || item->description().find(query) != std::string::npos)
 					&& !item->deleted()){
-				items.push_back(item);
+				std::shared_ptr<rss_item> newitem(new rss_item(NULL));
+				newitem->set_guid(item->guid());
+				newitem->set_title(item->title());
+				newitem->set_author(item->author());
+				newitem->set_link(item->link());
+
+				newitem->set_pubDate(item->pubDate_timestamp());
+
+				newitem->set_size(item->size());
+				newitem->set_unread(item->unread());
+				newitem->set_feedurl(item->feedurl());
+
+				newitem->set_enclosure_url(item->enclosure_url());
+				newitem->set_enclosure_type(item->enclosure_type());
+				newitem->set_enqueued(item->enqueued());
+				newitem->set_flags(item->flags());
+				newitem->set_base(item->get_base());
+
+				newitem->set_feedptr(item->get_feedptr());
+				newitem->set_cache(get_cache());
+
+				items.push_back(newitem);
 			}
 		}
 	} else {

--- a/src/feedlist_formaction.cpp
+++ b/src/feedlist_formaction.cpp
@@ -692,7 +692,7 @@ void feedlist_formaction::op_start_search() {
 		std::vector<std::shared_ptr<rss_item>> items;
 		try {
 			std::string utf8searchphrase = utils::convert_text(searchphrase, "utf-8", nl_langinfo(CODESET));
-			items = v->get_ctrl()->search_for_items(utf8searchphrase, "");
+			items = v->get_ctrl()->search_for_items(utf8searchphrase, NULL);
 		} catch (const dbexception& e) {
 			v->show_error(utils::strprintf(_("Error while searching for `%s': %s"), searchphrase.c_str(), e.what()));
 			return;

--- a/src/itemlist_formaction.cpp
+++ b/src/itemlist_formaction.cpp
@@ -569,9 +569,9 @@ void itemlist_formaction::qna_start_search() {
 	try {
 		std::string utf8searchphrase = utils::convert_text(searchphrase, "utf-8", nl_langinfo(CODESET));
 		if (show_searchresult) {
-			items = v->get_ctrl()->search_for_items(utf8searchphrase, "");
+			items = v->get_ctrl()->search_for_items(utf8searchphrase, NULL);
 		} else {
-			items = v->get_ctrl()->search_for_items(utf8searchphrase, feed->rssurl());
+			items = v->get_ctrl()->search_for_items(utf8searchphrase, feed);
 		}
 	} catch (const dbexception& e) {
 		v->show_error(utils::strprintf(_("Error while searching for `%s': %s"), searchphrase.c_str(), e.what()));


### PR DESCRIPTION
controller::search_for_items accepts a feedurl string and passes it down to the
cache. Since query feeds are not stored in the cache this causes all query feed
searches to return no results. The solution is to pass the feed object to
search_for_items and do a linear search from the items that have been already
loaded/matched if we are searching a query feed.

Also added an assert call in cache::search_for_items to prevent bugs like this in the future.

Fixes #313