### PR TITLE
HTMLRenderer: Strip newline characters

### DIFF
--- a/src/htmlrenderer.cpp
+++ b/src/htmlrenderer.cpp
@@ -595,6 +595,7 @@ void htmlrenderer::render(
 			} else if (inside_script || inside_style) {
 				// skip scripts and CSS styles
 			} else {
+				//strip leading whitespace
 				bool had_whitespace = false;
 				while (text.length() > 0 && (text[0] == '\n' || text[0] == ' ')) {
 					text.erase(0, 1);
@@ -603,6 +604,8 @@ void htmlrenderer::render(
 				if (line_is_nonempty(curline) && had_whitespace) {
 					curline.append(" ");
 				}
+				//strip newlines
+				text = utils::replace_all(text, "\n", " ");
 				curline.append(text);
 			}
 		}

--- a/test/htmlrenderer.cpp
+++ b/test/htmlrenderer.cpp
@@ -555,6 +555,19 @@ TEST_CASE("htmlrenderer: whitespace is erased at the beginning of the paragraph"
 	REQUIRE(links.size() == 0);
 }
 
+TEST_CASE("htmlrenderer: newlines are replaced with space") {
+	htmlrenderer r;
+
+	const std::string input = "newlines\nshould\nbe\nreplaced\nwith\na\nspace\ncharacter.";
+	std::vector<std::pair<LineType, std::string>> lines;
+	std::vector<linkpair> links;
+
+	REQUIRE_NOTHROW(r.render(input, lines, links, url));
+	REQUIRE(lines.size() == 1);
+	REQUIRE(lines[0] == p(wrappable, "newlines should be replaced with a space character."));
+	REQUIRE(links.size() == 0);
+}
+
 TEST_CASE("htmlrenderer: paragraph is just a long line of text") {
 	htmlrenderer r;
 


### PR DESCRIPTION
Make the html renderer strip newline characters from the text to prevent them from being passed down to stfl and causing rendering errors.

(Perhaps they should be replaced with a space character?)