### PR TITLE
Add config option to control SSL validation

### DIFF
--- a/doc/configcommands.dsv
+++ b/doc/configcommands.dsv
@@ -77,6 +77,7 @@ opml-url|<url> ...|""|If the OPML online subscription mode is enabled, then the 
 pager|[<path>/internal]|internal|If set to "internal", then the internal pager will be used. Otherwise, the article to be displayed will be rendered to be a temporary file and then displayed with the configured pager. If the pager path is set to an empty string, the content of the "PAGER" environment variable will be used. If the pager path contains a placeholder "%f", it will be replaced with the temporary filename.|less %f
 podcast-auto-enqueue|[yes/no]|no|If yes, then all podcast URLs that are found in articles are added to the podcast download queue. See the respective section in the documentation for more information on podcast support in newsbeuter.|podcast-auto-enqueue yes
 prepopulate-query-feeds|[yes/no]|no|If yes, then all query feeds are prepopulated with articles on startup.|prepopulate-query-feeds yes
+ssl-verify|[yes/no]|yes|If no, skip SSL certificate validation.|ssl-verify no
 proxy-auth-method|<method>|any|Set proxy authentication method. Allowed values: any, basic, digest, digest_ie (only available with libcurl 7.19.3 and newer), gssnegotiate, ntlm, anysafe.|proxy-auth-method ntlm
 proxy-auth|<auth>|n/a|Set the proxy authentication string.|proxy-auth user:password
 proxy-type|<type>|http|Set proxy type. Allowed values: http, socks4, socks4a, socks5.|proxy-type socks5

--- a/doc/example-config
+++ b/doc/example-config
@@ -916,6 +916,16 @@
 #
 # prepopulate-query-feeds yes
 
+####  ssl-verify
+#
+# If no, skip SSL certificate validation.
+#
+# Syntax: [yes/no]
+#
+# Default value: yes
+#
+# ssl-verify no
+
 ####  proxy-auth-method
 #
 # Set proxy authentication method. Allowed values: any, basic, digest,

--- a/rss/parser.cpp
+++ b/rss/parser.cpp
@@ -25,8 +25,8 @@ static size_t my_write_data(void *buffer, size_t size, size_t nmemb, void *userp
 
 namespace rsspp {
 
-parser::parser(unsigned int timeout, const char * user_agent, const char * proxy, const char * proxy_auth, curl_proxytype proxy_type)
-	: to(timeout), ua(user_agent), prx(proxy), prxauth(proxy_auth), prxtype(proxy_type), doc(0), lm(0) {
+parser::parser(unsigned int timeout, const char * user_agent, const char * proxy, const char * proxy_auth, curl_proxytype proxy_type, const bool ssl_verify)
+	: to(timeout), ua(user_agent), prx(proxy), prxauth(proxy_auth), prxtype(proxy_type), verify_ssl(ssl_verify), doc(0), lm(0) {
 }
 
 parser::~parser() {
@@ -90,7 +90,7 @@ feed parser::parse_url(const std::string& url, time_t lastmodified, const std::s
 		api->add_custom_headers(&custom_headers);
 	}
 	curl_easy_setopt(easyhandle, CURLOPT_URL, url.c_str());
-	curl_easy_setopt(easyhandle, CURLOPT_SSL_VERIFYPEER, 0);
+	curl_easy_setopt(easyhandle, CURLOPT_SSL_VERIFYPEER, verify_ssl);
 	curl_easy_setopt(easyhandle, CURLOPT_WRITEFUNCTION, my_write_data);
 	curl_easy_setopt(easyhandle, CURLOPT_WRITEDATA, &buf);
 	curl_easy_setopt(easyhandle, CURLOPT_NOSIGNAL, 1);

--- a/rss/rsspp.h
+++ b/rss/rsspp.h
@@ -73,7 +73,7 @@ class exception : public std::exception {
 
 class parser {
 	public:
-		parser(unsigned int timeout = 30, const char * user_agent = 0, const char * proxy = 0, const char * proxy_auth = 0, curl_proxytype proxy_type = CURLPROXY_HTTP);
+		parser(unsigned int timeout = 30, const char * user_agent = 0, const char * proxy = 0, const char * proxy_auth = 0, curl_proxytype proxy_type = CURLPROXY_HTTP, const bool ssl_verify = true);
 		~parser();
 		feed parse_url(const std::string& url, time_t lastmodified = 0, const std::string& etag = "", newsbeuter::remote_api * api = 0, const std::string& cookie_cache = "", CURL *ehandle = 0);
 		feed parse_buffer(const char * buffer, size_t size, const char * url = NULL);
@@ -95,6 +95,7 @@ class parser {
 		const char * prx;
 		const char * prxauth;
 		curl_proxytype prxtype;
+		const bool verify_ssl;
 		xmlDocPtr doc;
 		time_t lm;
 		std::string et;

--- a/src/configcontainer.cpp
+++ b/src/configcontainer.cpp
@@ -100,6 +100,7 @@ configcontainer::configcontainer()
 		{ "player", configdata("", configdata::PATH) },
 		{ "podcast-auto-enqueue", configdata("no", configdata::BOOL) },
 		{ "prepopulate-query-feeds", configdata("false", configdata::BOOL) },
+		{ "ssl-verify", configdata("true", configdata::BOOL) },
 		{ "proxy", configdata("", configdata::STR) },
 		{ "proxy-auth", configdata("", configdata::STR) },
 		{ "proxy-auth-method",

--- a/src/rss_parser.cpp
+++ b/src/rss_parser.cpp
@@ -161,7 +161,7 @@ void rss_parser::download_http(const std::string& uri) {
 		try {
 			std::string useragent = utils::get_useragent(cfgcont);
 			LOG(LOG_DEBUG, "rss_parser::download_http: user-agent = %s", useragent.c_str());
-			rsspp::parser p(cfgcont->get_configvalue_as_int("download-timeout"), useragent.c_str(), proxy.c_str(), proxy_auth.c_str(), utils::get_proxy_type(proxy_type));
+			rsspp::parser p(cfgcont->get_configvalue_as_int("download-timeout"), useragent.c_str(), proxy.c_str(), proxy_auth.c_str(), utils::get_proxy_type(proxy_type), cfgcont->get_configvalue_as_bool("ssl-verify"));
 			time_t lm = 0;
 			std::string etag;
 			if (!ign || !ign->matches_lastmodified(uri)) {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -849,7 +849,7 @@ void utils::set_common_curl_options(CURL * handle, configcontainer * cfg) {
 		cookie_cache = cfg->get_configvalue("cookie-cache");
 	}
 
-	curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, 0);
+	curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, cfg->get_configvalue_as_bool("ssl-verify"));
 	curl_easy_setopt(handle, CURLOPT_NOSIGNAL, 1);
 	curl_easy_setopt(handle, CURLOPT_ENCODING, "gzip, deflate");
 	curl_easy_setopt(handle, CURLOPT_TIMEOUT, dl_timeout);


### PR DESCRIPTION
Currently newsbeuter performs no validation on SSL certificates. Until a better solution is implemented (per feed SSL control) a global setting is better than doing no validation at all.