### PR TITLE
Consistency fix

### DIFF
--- a/include/tagsouppullparser.h
+++ b/include/tagsouppullparser.h
@@ -13,10 +13,10 @@ class tagsouppullparser {
 
 		tagsouppullparser();
 		virtual ~tagsouppullparser();
-		void setInput(std::istream& is);
-		std::string getAttributeValue(const std::string& name) const;
-		event getEventType() const;
-		std::string getText() const;
+		void set_input(std::istream& is);
+		std::string get_attribute_value(const std::string& name) const;
+		event get_event_type() const;
+		std::string get_text() const;
 		event next();
 
 	private:

--- a/src/htmlrenderer.cpp
+++ b/src/htmlrenderer.cpp
@@ -106,13 +106,13 @@ void htmlrenderer::render(
 	 *   - we then can iterate over all continuous elements, such as start tag, close tag, text element, ...
 	 */
 	tagsouppullparser xpp;
-	xpp.setInput(input);
+	xpp.set_input(input);
 
 	for (tagsouppullparser::event e = xpp.next(); e != tagsouppullparser::END_DOCUMENT; e = xpp.next()) {
 		std::string tagname;
 		switch (e) {
 		case tagsouppullparser::START_TAG:
-			tagname = xpp.getText();
+			tagname = xpp.get_text();
 			std::transform(tagname.begin(), tagname.end(), tagname.begin(), ::tolower);
 			current_tag = tags[tagname];
 
@@ -120,7 +120,7 @@ void htmlrenderer::render(
 			case TAG_A: {
 				std::string link;
 				try {
-					link = xpp.getAttributeValue("href");
+					link = xpp.get_attribute_value("href");
 				} catch (const std::invalid_argument& ) {
 					LOG(LOG_WARN,"htmlrenderer::render: found a tag with no href attribute");
 					link = "";
@@ -148,7 +148,7 @@ void htmlrenderer::render(
 			case TAG_EMBED: {
 				std::string type;
 				try {
-					type = xpp.getAttributeValue("type");
+					type = xpp.get_attribute_value("type");
 				} catch (const std::invalid_argument& ) {
 					LOG(LOG_WARN, "htmlrenderer::render: found embed object without type attribute");
 					type = "";
@@ -156,7 +156,7 @@ void htmlrenderer::render(
 				if (type == "application/x-shockwave-flash") {
 					std::string link;
 					try {
-						link = xpp.getAttributeValue("src");
+						link = xpp.get_attribute_value("src");
 					} catch (const std::invalid_argument& ) {
 						LOG(LOG_WARN, "htmlrenderer::render: found embed object without src attribute");
 						link = "";
@@ -188,13 +188,13 @@ void htmlrenderer::render(
 				std::string imgurl;
 				std::string imgtitle;
 				try {
-					imgurl = xpp.getAttributeValue("src");
+					imgurl = xpp.get_attribute_value("src");
 				} catch (const std::invalid_argument& ) {
 					LOG(LOG_WARN,"htmlrenderer::render: found img tag with no src attribute");
 					imgurl = "";
 				}
 				try {
-					imgtitle = xpp.getAttributeValue("title");
+					imgtitle = xpp.get_attribute_value("title");
 				} catch (const std::invalid_argument& ) {
 					imgtitle = "";
 				}
@@ -244,7 +244,7 @@ void htmlrenderer::render(
 					unsigned int ol_count = 1;
 					std::string ol_count_str;
 					try {
-						ol_count_str = xpp.getAttributeValue("start");
+						ol_count_str = xpp.get_attribute_value("start");
 					} catch (const std::invalid_argument& ) {
 						ol_count_str = "1";
 					}
@@ -253,7 +253,7 @@ void htmlrenderer::render(
 
 					std::string ol_type;
 					try {
-						ol_type = xpp.getAttributeValue("type");
+						ol_type = xpp.get_attribute_value("type");
 						if (ol_type != "1" && ol_type != "a" && ol_type != "A" && ol_type != "i" && ol_type != "I") {
 							ol_type = "1";
 						}
@@ -340,7 +340,7 @@ void htmlrenderer::render(
 
 				bool border = false;
 				try {
-					std::string b = xpp.getAttributeValue("border");
+					std::string b = xpp.get_attribute_value("border");
 					border = (utils::to_u(b, 0) > 0);
 				} catch (const std::invalid_argument& ) {
 					// is ok, no border then
@@ -357,7 +357,7 @@ void htmlrenderer::render(
 			case TAG_TH: {
 				size_t span = 1;
 				try {
-					span = utils::to_u(xpp.getAttributeValue("colspan"), 1);
+					span = utils::to_u(xpp.get_attribute_value("colspan"), 1);
 				} catch (const std::invalid_argument& ) {
 					// is ok, span 1 then
 				}
@@ -370,7 +370,7 @@ void htmlrenderer::render(
 			case TAG_TD: {
 				size_t span = 1;
 				try {
-					span = utils::to_u(xpp.getAttributeValue("colspan"), 1);
+					span = utils::to_u(xpp.get_attribute_value("colspan"), 1);
 				} catch (const std::invalid_argument& ) {
 					// is ok, span 1 then
 				}
@@ -382,7 +382,7 @@ void htmlrenderer::render(
 			break;
 
 		case tagsouppullparser::END_TAG:
-			tagname = xpp.getText();
+			tagname = xpp.get_text();
 			std::transform(tagname.begin(), tagname.end(), tagname.begin(), ::tolower);
 			current_tag = tags[tagname];
 
@@ -572,7 +572,7 @@ void htmlrenderer::render(
 			break;
 
 		case tagsouppullparser::TEXT: {
-			auto text = utils::quote_for_stfl(xpp.getText());
+			auto text = utils::quote_for_stfl(xpp.get_text());
 			if (itunes_hack) {
 				std::vector<std::string> paragraphs = utils::tokenize_nl(text);
 				for (auto paragraph : paragraphs) {

--- a/src/tagsouppullparser.cpp
+++ b/src/tagsouppullparser.cpp
@@ -25,12 +25,12 @@ tagsouppullparser::tagsouppullparser() : inputstream(0), current_event(START_DOC
 tagsouppullparser::~tagsouppullparser() {
 }
 
-void tagsouppullparser::setInput(std::istream& is) {
+void tagsouppullparser::set_input(std::istream& is) {
 	inputstream = &is;
 	current_event = START_DOCUMENT;
 }
 
-std::string tagsouppullparser::getAttributeValue(const std::string& name) const {
+std::string tagsouppullparser::get_attribute_value(const std::string& name) const {
 	for (auto attr : attributes) {
 		if (attr.first == name) {
 			return attr.second;
@@ -39,11 +39,11 @@ std::string tagsouppullparser::getAttributeValue(const std::string& name) const 
 	throw std::invalid_argument(_("attribute not found"));
 }
 
-tagsouppullparser::event tagsouppullparser::getEventType() const {
+tagsouppullparser::event tagsouppullparser::get_event_type() const {
 	return current_event;
 }
 
-std::string tagsouppullparser::getText() const {
+std::string tagsouppullparser::get_text() const {
 	return text;
 }
 
@@ -79,7 +79,7 @@ tagsouppullparser::event tagsouppullparser::next() {
 	case END_DOCUMENT:
 		break;
 	}
-	return getEventType();
+	return get_event_type();
 }
 
 void tagsouppullparser::skip_whitespace() {

--- a/test/tagsouppullparser.cpp
+++ b/test/tagsouppullparser.cpp
@@ -15,59 +15,59 @@ TEST_CASE("Tagsoup pull parser behaves properly") {
 
 	tagsouppullparser xpp;
 	tagsouppullparser::event e;
-	xpp.setInput(input_stream);
+	xpp.set_input(input_stream);
 
-	e = xpp.getEventType();
+	e = xpp.get_event_type();
 	REQUIRE(e == tagsouppullparser::START_DOCUMENT);
 
 	e = xpp.next();
 	REQUIRE(e == tagsouppullparser::START_TAG);
-	REQUIRE(xpp.getText() == "test");
+	REQUIRE(xpp.get_text() == "test");
 
 	e = xpp.next();
 	REQUIRE(e == tagsouppullparser::START_TAG);
-	REQUIRE(xpp.getText() == "foo");
-	REQUIRE(xpp.getAttributeValue("quux") == "asdf");
-	REQUIRE(xpp.getAttributeValue("bar") == "qqq");
+	REQUIRE(xpp.get_text() == "foo");
+	REQUIRE(xpp.get_attribute_value("quux") == "asdf");
+	REQUIRE(xpp.get_attribute_value("bar") == "qqq");
 
 	e = xpp.next();
 	REQUIRE(e == tagsouppullparser::TEXT);
-	REQUIRE(xpp.getText() == "text");
+	REQUIRE(xpp.get_text() == "text");
 
 	e = xpp.next();
 	REQUIRE(e == tagsouppullparser::END_TAG);
-	REQUIRE(xpp.getText() == "foo");
+	REQUIRE(xpp.get_text() == "foo");
 
 	e = xpp.next();
 	REQUIRE(e == tagsouppullparser::TEXT);
-	REQUIRE(xpp.getText() == "more text");
+	REQUIRE(xpp.get_text() == "more text");
 
 	e = xpp.next();
 	REQUIRE(e == tagsouppullparser::START_TAG);
-	REQUIRE(xpp.getText() == "more");
+	REQUIRE(xpp.get_text() == "more");
 
 	e = xpp.next();
 	REQUIRE(e == tagsouppullparser::TEXT);
-	REQUIRE(xpp.getText() == "\"!@");
+	REQUIRE(xpp.get_text() == "\"!@");
 
 	e = xpp.next();
 	REQUIRE(e == tagsouppullparser::END_TAG);
-	REQUIRE(xpp.getText() == "more");
+	REQUIRE(xpp.get_text() == "more");
 
 	e = xpp.next();
 	REQUIRE(e == tagsouppullparser::START_TAG);
-	REQUIRE(xpp.getText() == "xxx");
-	REQUIRE(xpp.getAttributeValue("foo") == "bar");
-	REQUIRE(xpp.getAttributeValue("baz") == "qu ux");
-	REQUIRE(xpp.getAttributeValue("hi") == "ho ho ho");
+	REQUIRE(xpp.get_text() == "xxx");
+	REQUIRE(xpp.get_attribute_value("foo") == "bar");
+	REQUIRE(xpp.get_attribute_value("baz") == "qu ux");
+	REQUIRE(xpp.get_attribute_value("hi") == "ho ho ho");
 
 	e = xpp.next();
 	REQUIRE(e == tagsouppullparser::END_TAG);
-	REQUIRE(xpp.getText() == "xxx");
+	REQUIRE(xpp.get_text() == "xxx");
 
 	e = xpp.next();
 	REQUIRE(e == tagsouppullparser::END_TAG);
-	REQUIRE(xpp.getText() == "test");
+	REQUIRE(xpp.get_text() == "test");
 
 	e = xpp.next();
 	REQUIRE(e == tagsouppullparser::END_DOCUMENT);
@@ -84,14 +84,14 @@ TEST_CASE("<br>, <br/> and <br /> behave the same way") {
 	for (auto input : {"<br>", "<br/>", "<br />"}) {
 		SECTION(input) {
 			input_stream.str(input);
-			parser.setInput(input_stream);
+			parser.set_input(input_stream);
 
-			event = parser.getEventType();
+			event = parser.get_event_type();
 			REQUIRE(event == tagsouppullparser::START_DOCUMENT);
 
 			event = parser.next();
 			REQUIRE(event == tagsouppullparser::START_TAG);
-			REQUIRE(parser.getText() == "br");
+			REQUIRE(parser.get_text() == "br");
 
 			event = parser.next();
 			REQUIRE(event == tagsouppullparser::END_DOCUMENT);


### PR DESCRIPTION
Tagsouppullparser used camelCase for a few functions, switched to snake_case to be consistent with the rest of the project.