### PR TITLE
Check for iconv() TRANSLIT support

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -46,6 +46,7 @@ class utils {
 		static bool try_fs_lock(const std::string& lock_file, pid_t & pid);
 		static void remove_fs_lock(const std::string& lock_file);
 
+		static std::string translit(const std::string& tocode, const std::string& fromcode);
 		static std::string convert_text(const std::string& text, const std::string& tocode, const std::string& fromcode);
 
 		static std::string get_command_output(const std::string& cmd);

--- a/include/utils.h
+++ b/include/utils.h
@@ -46,6 +46,7 @@ class utils {
 		static bool try_fs_lock(const std::string& lock_file, pid_t & pid);
 		static void remove_fs_lock(const std::string& lock_file);
 
+		static std::string translit(const char* tocode, const std::string& fromcode);
 		static std::string translit(const std::string& tocode, const std::string& fromcode);
 		static std::string convert_text(const std::string& text, const std::string& tocode, const std::string& fromcode);
 

--- a/src/stflpp.cpp
+++ b/src/stflpp.cpp
@@ -4,6 +4,7 @@
 #include <cerrno>
 
 #include <langinfo.h>
+#include <utils.h>
 
 namespace newsbeuter {
 
@@ -16,7 +17,7 @@ namespace newsbeuter {
  */
 
 stfl::form::form(const std::string& text) : f(0) {
-	ipool = stfl_ipool_create((std::string(nl_langinfo(CODESET)) + "//TRANSLIT").c_str());
+	ipool = stfl_ipool_create(utils::translit(std::string(nl_langinfo(CODESET)), "WCHAR_T").c_str());
 	if (!ipool) {
 		throw exception(errno);
 	}
@@ -82,7 +83,7 @@ static std::mutex quote_mtx;
 
 std::string stfl::quote(const std::string& text) {
 	std::lock_guard<std::mutex> lock(quote_mtx);
-	stfl_ipool * ipool = stfl_ipool_create((std::string(nl_langinfo(CODESET)) + "//TRANSLIT").c_str());
+	stfl_ipool * ipool = stfl_ipool_create(utils::translit(std::string(nl_langinfo(CODESET)), "WCHAR_T").c_str());
 	std::string retval = stfl_ipool_fromwc(ipool,stfl_quote(stfl_ipool_towc(ipool,text.c_str())));
 	stfl_ipool_destroy(ipool);
 	return retval;

--- a/src/stflpp.cpp
+++ b/src/stflpp.cpp
@@ -17,7 +17,7 @@ namespace newsbeuter {
  */
 
 stfl::form::form(const std::string& text) : f(0) {
-	ipool = stfl_ipool_create(utils::translit(std::string(nl_langinfo(CODESET)), "WCHAR_T").c_str());
+	ipool = stfl_ipool_create(utils::translit(nl_langinfo(CODESET), "WCHAR_T").c_str());
 	if (!ipool) {
 		throw exception(errno);
 	}
@@ -83,7 +83,7 @@ static std::mutex quote_mtx;
 
 std::string stfl::quote(const std::string& text) {
 	std::lock_guard<std::mutex> lock(quote_mtx);
-	stfl_ipool * ipool = stfl_ipool_create(utils::translit(std::string(nl_langinfo(CODESET)), "WCHAR_T").c_str());
+	stfl_ipool * ipool = stfl_ipool_create(utils::translit(nl_langinfo(CODESET), "WCHAR_T").c_str());
 	std::string retval = stfl_ipool_fromwc(ipool,stfl_quote(stfl_ipool_towc(ipool,text.c_str())));
 	stfl_ipool_destroy(ipool);
 	return retval;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -256,6 +256,11 @@ bool utils::try_fs_lock(const std::string& lock_file, pid_t & pid) {
 	return false;
 }
 
+std::string utils::translit(const char* tocode, const std::string& fromcode)
+{
+	return translit(std::string(tocode), fromcode);
+}
+
 std::string utils::translit(const std::string& tocode, const std::string& fromcode)
 {
 	std::string tlit = "//TRANSLIT";


### PR DESCRIPTION
Some iconv() implementations don't support transliteration.
When iconv with //TRANSLIT is first attempted and fails,
try again without it, and remember the result.

Fixes #364
Fixes #174 