### PR TITLE
Toggle unread article also now undeletes (#330)

### DIFF
--- a/doc/keycmds.dsv
+++ b/doc/keycmds.dsv
@@ -14,7 +14,7 @@ open-in-browser:o:Opens the URL associated with the current article.
 open-in-browser-and-mark-read:O:Opens the URL associated with the current article and marks the article as read.
 help:?:Runs the help screen.
 toggle-source-view:^U:Toggles between the HTML view and the source view in the article view.
-toggle-article-read:N:Toggle the read flag for the currently selected article.
+toggle-article-read:N:Toggle the read flag for the currently selected article, and clears delete flag if set.
 toggle-show-read-feeds:l:Toggle whether read feeds should be shown in the feed list.
 show-urls:u:Show all URLs in the article in a list (similar to urlview).
 clear-tag:^T:Clear current tag.

--- a/src/itemlist_formaction.cpp
+++ b/src/itemlist_formaction.cpp
@@ -124,6 +124,10 @@ void itemlist_formaction::process_operation(operation op, bool automatic, std::v
 					}
 					v->set_status("");
 				} else {
+					// mark as undeleted
+					visible_items[itempos].first->set_deleted(false);
+					v->get_ctrl()->mark_deleted(visible_items[itempos].first->guid(), false);
+					// toggle read
 					bool unread = visible_items[itempos].first->unread();
 					visible_items[itempos].first->set_unread(!unread);
 					v->get_ctrl()->mark_article_read(visible_items[itempos].first->guid(), unread);


### PR DESCRIPTION
This fixes Issue #330, and will make sure an item is undeleted when and item is toggled unread.

Please correct me if I'm not doing this right -- I haven't contributed on Github that much.  It's late Friday, I'm in a mood, so I picked one of the top issues that you had tagged.