### PR TITLE
Install locale file with right name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,8 +214,8 @@ install-mo: mo-files
 		lang=`echo $$mofile | sed 's/\.mo$$//'`; \
 		dir=$(DESTDIR)$(localedir)/$$lang/LC_MESSAGES; \
 		$(MKDIR) $$dir ; \
-		$(INSTALL) -m 644 $$mof $$dir/$(PACKAGE).mo ; \
-		echo "Installing $$mofile as $$dir/$(PACKAGE).mo" ; \
+		$(INSTALL) -m 644 $$mof $$dir/$(NEWSBEUTER).mo ; \
+		echo "Installing $$mofile as $$dir/$(NEWSBEUTER).mo" ; \
 	done
 
 uninstall-mo:
@@ -223,8 +223,8 @@ uninstall-mo:
 		mofile=`basename $$mof` ; \
 		lang=`echo $$mofile | sed 's/\.mo$$//'`; \
 		dir=$(DESTDIR)$(localedir)/$$lang/LC_MESSAGES; \
-		$(RM) -f $$dir/$(PACKAGE).mo ; \
-		echo "Uninstalling $$dir/$(PACKAGE).mo" ; \
+		$(RM) -f $$dir/$(NEWSBEUTER).mo ; \
+		echo "Uninstalling $$dir/$(NEWSBEUTER).mo" ; \
 	done
 
 # tests and coverage reports


### PR DESCRIPTION
The current way of installing locale file can lead to a wrong filename because the name of the locale file is hard-coded in config.h as a macro. Indeed if you pass a custom PACKAGE variable, for example newsbeuter-2.10, to make, it will install locale file with this name but newsbeuter looks for a file named newsbeuter.mo. This commit fixes this by replacing the variable PACKAGE by the variable NEWSBEUTER during installation of .mo files. So even if you change PACKAGE, the locale file is installed with the right name.