### PR TITLE
Hide the cursor

### DIFF
--- a/src/view.cpp
+++ b/src/view.cpp
@@ -160,6 +160,8 @@ void view::run() {
 
 	stfl::reset();
 
+	curs_set(0);
+
 	/*
 	 * This is the main "event" loop of newsbeuter.
 	 */


### PR DESCRIPTION
This change hides the terminal cursor in the Newsbeuter UI. Fairly straightforward.

This also fixes #344.