### PR TITLE
Don't use tabs for alignment

### DIFF
--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -20,95 +20,430 @@ struct op_desc {
  * This is the list of operations, defining operation, operation name (for keybindings), default key, description, and where it's valid
  */
 static op_desc opdescs[] = {
-	{ OP_OPEN,				"open",						"ENTER", _("Open feed/article"),				KM_FEEDLIST | KM_FILEBROWSER | KM_HELP | KM_ARTICLELIST | KM_TAGSELECT | KM_FILTERSELECT | KM_URLVIEW | KM_PODBEUTER | KM_DIALOGS },
-	{ OP_QUIT,				"quit",						"q",	_("Return to previous dialog/Quit"),	KM_FEEDLIST | KM_FILEBROWSER | KM_HELP | KM_ARTICLELIST | KM_ARTICLE | KM_TAGSELECT | KM_FILTERSELECT | KM_URLVIEW | KM_PODBEUTER | KM_DIALOGS },
-	{ OP_HARDQUIT,			"hard-quit",				"Q",	_("Quit program,  no confirmation"),	KM_FEEDLIST | KM_FILEBROWSER | KM_HELP | KM_ARTICLELIST | KM_ARTICLE | KM_TAGSELECT | KM_FILTERSELECT | KM_URLVIEW | KM_PODBEUTER | KM_DIALOGS },
-	{ OP_RELOAD,			"reload",					"r",	_("Reload currently selected feed"),	KM_FEEDLIST },
-	{ OP_RELOADALL,			"reload-all",				"R",	_("Reload all feeds"),					KM_FEEDLIST },
-	{ OP_MARKFEEDREAD,		"mark-feed-read",			"A",	_("Mark feed read"),					KM_FEEDLIST | KM_ARTICLELIST },
-	{ OP_MARKALLFEEDSREAD,	"mark-all-feeds-read",		"C",	_("Mark all feeds read"),				KM_FEEDLIST },
-	{ OP_SAVE,				"save",						"s",	_("Save article"),						KM_ARTICLELIST | KM_ARTICLE },
-	{ OP_NEXT,				"next",						"J",	_("Go to next article"),			KM_FEEDLIST | KM_ARTICLELIST | KM_ARTICLE },
-	{ OP_PREV,				"prev",						"K",	_("Go to previous article"),		KM_FEEDLIST | KM_ARTICLELIST | KM_ARTICLE },
-	{ OP_NEXTUNREAD,		"next-unread",				"n",	_("Go to next unread article"),			KM_FEEDLIST | KM_ARTICLELIST | KM_ARTICLE },
-	{ OP_PREVUNREAD,		"prev-unread",				"p",	_("Go to previous unread article"),		KM_FEEDLIST | KM_ARTICLELIST | KM_ARTICLE },
-	{ OP_RANDOMUNREAD,		"random-unread",			"^K",	_("Go to a random unread article"),		KM_FEEDLIST | KM_ARTICLELIST | KM_ARTICLE },
-	{ OP_OPENBROWSER_AND_MARK, "open-in-browser-and-mark-read",                   "O",    _("Open article in browser and mark read"),           KM_ARTICLELIST },
-	{ OP_OPENINBROWSER,		"open-in-browser",			"o",	_("Open article in browser"),			KM_FEEDLIST | KM_ARTICLELIST | KM_ARTICLE },
-	{ OP_OPENALLUNREADINBROWSER, "open-all-unread-in-browser", "",	_("Open all unread items of selected feed in browser"),		KM_FEEDLIST | KM_ARTICLELIST },
-	{ OP_OPENALLUNREADINBROWSER_AND_MARK, "open-all-unread-in-browser-and-mark-read", "", _("Open all unread items of selected feed in browser and mark read"),	KM_FEEDLIST | KM_ARTICLELIST },
-	{ OP_HELP,				"help",						"?",	_("Open help dialog"),					KM_FEEDLIST | KM_ARTICLELIST | KM_ARTICLE | KM_PODBEUTER },
-	{ OP_TOGGLESOURCEVIEW,	"toggle-source-view",		"^U",	_("Toggle source view"),				KM_ARTICLE },
-	{ OP_TOGGLEITEMREAD,	"toggle-article-read",		"N",	_("Toggle read status for article"),	KM_ARTICLELIST | KM_ARTICLE },
-	{ OP_TOGGLESHOWREAD,	"toggle-show-read-feeds",	"l",	_("Toggle show read feeds/articles"),	KM_FEEDLIST | KM_ARTICLELIST },
-	{ OP_SHOWURLS,			"show-urls",				"u",	_("Show URLs in current article"),		KM_ARTICLE | KM_ARTICLELIST },
-	{ OP_CLEARTAG,			"clear-tag",				"^T",	_("Clear current tag"),					KM_FEEDLIST },
-	{ OP_SETTAG,			"set-tag",					"t",	_("Select tag"),						KM_FEEDLIST },
-	{ OP_SETTAG,			"select-tag",				"t",	_("Select tag"),						KM_FEEDLIST },
-	{ OP_SEARCH,			"open-search",				"/",	_("Open search dialog"),				KM_FEEDLIST | KM_HELP | KM_ARTICLELIST | KM_ARTICLE },
-	{ OP_GOTO_URL,			"goto-url",				"#",	_("Goto URL #"),				KM_ARTICLE },
-	{ OP_ENQUEUE,			"enqueue",					"e",	_("Add download to queue"),				KM_ARTICLE },
-	{ OP_RELOADURLS,		"reload-urls",				"^R",	_("Reload the list of URLs from the configuration"),	KM_FEEDLIST },
-	{ OP_PB_DOWNLOAD,		"pb-download",				"d",	_("Download file"),						KM_PODBEUTER },
-	{ OP_PB_CANCEL,			"pb-cancel",				"c",	_("Cancel download"),					KM_PODBEUTER },
-	{ OP_PB_DELETE,			"pb-delete",				"D",	_("Mark download as deleted"),			KM_PODBEUTER },
-	{ OP_PB_PURGE,			"pb-purge",					"P",	_("Purge finished and deleted downloads from queue"),	KM_PODBEUTER },
-	{ OP_PB_TOGGLE_DLALL,	"pb-toggle-download-all",	"a",	_("Toggle automatic download on/off"),	KM_PODBEUTER },
-	{ OP_PB_PLAY,			"pb-play",					"p",	_("Start player with currently selected download"),		KM_PODBEUTER },
-	{ OP_PB_MARK_FINISHED,  "pb-mark-as-finished",          "m",    _("Mark file as finished (not played)"), KM_PODBEUTER },
-	{ OP_PB_MOREDL,			"pb-increase-max-dls",		"+",	_("Increase the number of concurrent downloads"),		KM_PODBEUTER },
-	{ OP_PB_LESSDL,			"pb-decreate-max-dls",		"-",	_("Decrease the number of concurrent downloads"),		KM_PODBEUTER },
-	{ OP_REDRAW,			"redraw",					"^L",	_("Redraw screen"),						KM_SYSKEYS },
-	{ OP_CMDLINE,			"cmdline",					":",	_("Open the commandline"),				KM_NEWSBEUTER },
-	{ OP_SETFILTER,			"set-filter",				"F",	_("Set a filter"),						KM_FEEDLIST | KM_ARTICLELIST },
-	{ OP_SELECTFILTER,		"select-filter",			"f",	_("Select a predefined filter"),		KM_FEEDLIST | KM_ARTICLELIST },
-	{ OP_CLEARFILTER,		"clear-filter",				"^F",	_("Clear currently set filter"),		KM_FEEDLIST | KM_HELP | KM_ARTICLELIST },
-	{ OP_BOOKMARK,			"bookmark",					"^B",	_("Bookmark current link/article"),		KM_ARTICLELIST | KM_ARTICLE | KM_URLVIEW },
-	{ OP_EDITFLAGS,			"edit-flags",				"^E",	_("Edit flags"),						KM_ARTICLELIST | KM_ARTICLE },
-	{ OP_NEXTFEED,			"next-feed",				"j",	_("Go to next feed"),					KM_ARTICLELIST },
-	{ OP_PREVFEED,			"prev-feed",				"k",	_("Go to previous feed"),				KM_ARTICLELIST },
-	{ OP_NEXTUNREADFEED,	"next-unread-feed",			"^N",	_("Go to next unread feed"),			KM_ARTICLELIST },
-	{ OP_PREVUNREADFEED,	"prev-unread-feed",			"^P",	_("Go to previous unread feed"),		KM_ARTICLELIST },
-	{ OP_MACROPREFIX,		"macro-prefix",				",",	_("Call a macro"),						KM_NEWSBEUTER  },
-	{ OP_DELETE,			"delete-article",			"D",	_("Delete article"),					KM_ARTICLELIST | KM_ARTICLE },
-	{ OP_PURGE_DELETED,		"purge-deleted",			"$",	_("Purge deleted articles"),			KM_ARTICLELIST },
-	{ OP_EDIT_URLS,			"edit-urls",				"E",	_("Edit subscribed URLs"),				KM_FEEDLIST | KM_ARTICLELIST },
-	{ OP_CLOSEDIALOG,		"close-dialog",				"^X",	_("Close currently selected dialog"),	KM_DIALOGS },
-	{ OP_VIEWDIALOGS,		"view-dialogs",				"v",	_("View list of open dialogs"),			KM_NEWSBEUTER },
-	{ OP_NEXTDIALOG,		"next-dialog",				"^V",	_("Go to next dialog"),					KM_NEWSBEUTER },
-	{ OP_PREVDIALOG,		"prev-dialog",				"^G",	_("Go to previous dialog"),				KM_NEWSBEUTER },
-	{ OP_PIPE_TO,			"pipe-to",					"|",	_("Pipe article to command"),			KM_ARTICLE | KM_ARTICLELIST },
-	{ OP_SORT,				"sort",						"g",	_("Sort current list"),					KM_FEEDLIST | KM_ARTICLELIST },
-	{ OP_REVSORT,			"rev-sort",					"G",	_("Sort current list (reverse)"),		KM_FEEDLIST | KM_ARTICLELIST },
+	{
+		OP_OPEN, "open", "ENTER",
+		_("Open feed/article"),
+		KM_FEEDLIST | KM_FILEBROWSER | KM_HELP | KM_ARTICLELIST | KM_TAGSELECT |
+			KM_FILTERSELECT | KM_URLVIEW | KM_PODBEUTER | KM_DIALOGS
+	},
+	{
+		OP_QUIT, "quit", "q",
+		_("Return to previous dialog/Quit"),
+		KM_FEEDLIST | KM_FILEBROWSER | KM_HELP | KM_ARTICLELIST | KM_ARTICLE |
+			KM_TAGSELECT | KM_FILTERSELECT | KM_URLVIEW | KM_PODBEUTER |
+			KM_DIALOGS
+	},
+	{
+		OP_HARDQUIT, "hard-quit", "Q",
+		_("Quit program,  no confirmation"),
+		KM_FEEDLIST | KM_FILEBROWSER | KM_HELP | KM_ARTICLELIST | KM_ARTICLE |
+			KM_TAGSELECT | KM_FILTERSELECT | KM_URLVIEW | KM_PODBEUTER |
+			KM_DIALOGS
+	},
+	{
+		OP_RELOAD, "reload", "r",
+		_("Reload currently selected feed"),
+		KM_FEEDLIST
+	},
+	{
+		OP_RELOADALL, "reload-all", "R",
+		_("Reload all feeds"),
+		KM_FEEDLIST
+	},
+	{
+		OP_MARKFEEDREAD, "mark-feed-read", "A",
+		_("Mark feed read"),
+		KM_FEEDLIST | KM_ARTICLELIST
+	},
+	{
+		OP_MARKALLFEEDSREAD, "mark-all-feeds-read", "C",
+		_("Mark all feeds read"),
+		KM_FEEDLIST
+	},
+	{
+		OP_SAVE, "save", "s",
+		_("Save article"),
+		KM_ARTICLELIST | KM_ARTICLE
+	},
+	{
+		OP_NEXT, "next", "J",
+		_("Go to next article"),
+		KM_FEEDLIST | KM_ARTICLELIST | KM_ARTICLE
+	},
+	{
+		OP_PREV, "prev", "K",
+		_("Go to previous article"),
+		KM_FEEDLIST | KM_ARTICLELIST | KM_ARTICLE
+	},
+	{
+		OP_NEXTUNREAD, "next-unread", "n",
+		_("Go to next unread article"),
+		KM_FEEDLIST | KM_ARTICLELIST | KM_ARTICLE
+	},
+	{
+		OP_PREVUNREAD, "prev-unread", "p",
+		_("Go to previous unread article"),
+		KM_FEEDLIST | KM_ARTICLELIST | KM_ARTICLE
+	},
+	{
+		OP_RANDOMUNREAD, "random-unread", "^K",
+		_("Go to a random unread article"),
+		KM_FEEDLIST | KM_ARTICLELIST | KM_ARTICLE
+	},
+	{
+		OP_OPENBROWSER_AND_MARK, "open-in-browser-and-mark-read", "O",
+		_("Open article in browser and mark read"),
+		KM_ARTICLELIST
+	},
+	{
+		OP_OPENALLUNREADINBROWSER, "open-all-unread-in-browser", "",
+		_("Open all unread items of selected feed in browser"),
+		KM_FEEDLIST | KM_ARTICLELIST
+	},
+	{
+		OP_OPENALLUNREADINBROWSER_AND_MARK, "open-all-unread-in-browser-and-mark-read", "",
+		_("Open all unread items of selected feed in browser and mark read"),
+		KM_FEEDLIST | KM_ARTICLELIST
+	},
+	{
+		OP_OPENINBROWSER, "open-in-browser", "o",
+		_("Open article in browser"),
+		KM_FEEDLIST | KM_ARTICLELIST | KM_ARTICLE
+	},
+	{
+		OP_HELP, "help", "?",
+		_("Open help dialog"),
+		KM_FEEDLIST | KM_ARTICLELIST | KM_ARTICLE | KM_PODBEUTER
+	},
+	{
+		OP_TOGGLESOURCEVIEW, "toggle-source-view", "^U",
+		_("Toggle source view"),
+		KM_ARTICLE
+	},
+	{
+		OP_TOGGLEITEMREAD, "toggle-article-read", "N",
+		_("Toggle read status for article"),
+		KM_ARTICLELIST | KM_ARTICLE
+	},
+	{
+		OP_TOGGLESHOWREAD, "toggle-show-read-feeds", "l",
+		_("Toggle show read feeds/articles"),
+		KM_FEEDLIST | KM_ARTICLELIST
+	},
+	{
+		OP_SHOWURLS, "show-urls", "u",
+		_("Show URLs in current article"),
+		KM_ARTICLE | KM_ARTICLELIST
+	},
+	{
+		OP_CLEARTAG, "clear-tag", "^T",
+		_("Clear current tag"),
+		KM_FEEDLIST
+	},
+	{
+		OP_SETTAG, "set-tag", "t",
+		_("Select tag"),
+		KM_FEEDLIST
+	},
+	{
+		OP_SETTAG, "select-tag", "t",
+		_("Select tag"),
+		KM_FEEDLIST
+	},
+	{
+		OP_SEARCH, "open-search", "/",
+		_("Open search dialog"),
+		KM_FEEDLIST | KM_HELP | KM_ARTICLELIST | KM_ARTICLE
+	},
+	{
+		OP_GOTO_URL, "goto-url", "#",
+		_("Goto URL #"),
+		KM_ARTICLE
+	},
+	{
+		OP_ENQUEUE, "enqueue", "e",
+		_("Add download to queue"),
+		KM_ARTICLE
+	},
+	{
+		OP_RELOADURLS, "reload-urls", "^R",
+		_("Reload the list of URLs from the configuration"),
+		KM_FEEDLIST
+	},
+	{
+		OP_PB_DOWNLOAD, "pb-download", "d",
+		_("Download file"),
+		KM_PODBEUTER
+	},
+	{
+		OP_PB_CANCEL, "pb-cancel", "c",
+		_("Cancel download"),
+		KM_PODBEUTER
+	},
+	{
+		OP_PB_DELETE, "pb-delete", "D",
+		_("Mark download as deleted"),
+		KM_PODBEUTER
+	},
+	{
+		OP_PB_PURGE, "pb-purge", "P",
+		_("Purge finished and deleted downloads from queue"),
+		KM_PODBEUTER
+	},
+	{
+		OP_PB_TOGGLE_DLALL, "pb-toggle-download-all", "a",
+		_("Toggle automatic download on/off"),
+		KM_PODBEUTER
+	},
+	{
+		OP_PB_PLAY, "pb-play", "p",
+		_("Start player with currently selected download"),
+		KM_PODBEUTER
+	},
+	{
+		OP_PB_MARK_FINISHED, "pb-mark-as-finished", "m",
+		_("Mark file as finished (not played)"),
+		KM_PODBEUTER
+	},
+	{
+		OP_PB_MOREDL, "pb-increase-max-dls", "+",
+		_("Increase the number of concurrent downloads"),
+		KM_PODBEUTER
+	},
+	{
+		OP_PB_LESSDL, "pb-decreate-max-dls", "-",
+		_("Decrease the number of concurrent downloads"),
+		KM_PODBEUTER
+	},
+	{
+		OP_REDRAW, "redraw", "^L",
+		_("Redraw screen"),
+		KM_SYSKEYS
+	},
+	{
+		OP_CMDLINE, "cmdline", ":",
+		_("Open the commandline"),
+		KM_NEWSBEUTER
+	},
+	{
+		OP_SETFILTER, "set-filter", "F",
+		_("Set a filter"),
+		KM_FEEDLIST | KM_ARTICLELIST
+	},
+	{
+		OP_SELECTFILTER, "select-filter", "f",
+		_("Select a predefined filter"),
+		KM_FEEDLIST | KM_ARTICLELIST
+	},
+	{
+		OP_CLEARFILTER, "clear-filter", "^F",
+		_("Clear currently set filter"),
+		KM_FEEDLIST | KM_HELP | KM_ARTICLELIST
+	},
+	{
+		OP_BOOKMARK, "bookmark", "^B",
+		_("Bookmark current link/article"),
+		KM_ARTICLELIST | KM_ARTICLE | KM_URLVIEW
+	},
+	{
+		OP_EDITFLAGS, "edit-flags", "^E",
+		_("Edit flags"),
+		KM_ARTICLELIST | KM_ARTICLE
+	},
+	{
+		OP_NEXTFEED, "next-feed", "j",
+		_("Go to next feed"),
+		KM_ARTICLELIST
+	},
+	{
+		OP_PREVFEED, "prev-feed", "k",
+		_("Go to previous feed"),
+		KM_ARTICLELIST
+	},
+	{
+		OP_NEXTUNREADFEED, "next-unread-feed", "^N",
+		_("Go to next unread feed"),
+		KM_ARTICLELIST
+	},
+	{
+		OP_PREVUNREADFEED, "prev-unread-feed", "^P",
+		_("Go to previous unread feed"),
+		KM_ARTICLELIST
+	},
+	{
+		OP_MACROPREFIX, "macro-prefix", ",",
+		_("Call a macro"), KM_NEWSBEUTER
+	},
+	{
+		OP_DELETE, "delete-article", "D",
+		_("Delete article"), KM_ARTICLELIST | KM_ARTICLE
+	},
+	{
+		OP_PURGE_DELETED, "purge-deleted", "$",
+		_("Purge deleted articles"),
+		KM_ARTICLELIST
+	},
+	{
+		OP_EDIT_URLS, "edit-urls", "E",
+		_("Edit subscribed URLs"),
+		KM_FEEDLIST | KM_ARTICLELIST
+	},
+	{
+		OP_CLOSEDIALOG, "close-dialog", "^X",
+		_("Close currently selected dialog"),
+		KM_DIALOGS
+	},
+	{
+		OP_VIEWDIALOGS, "view-dialogs", "v",
+		_("View list of open dialogs"),
+		KM_NEWSBEUTER
+	},
+	{
+		OP_NEXTDIALOG, "next-dialog", "^V",
+		_("Go to next dialog"),
+		KM_NEWSBEUTER
+	},
+	{
+		OP_PREVDIALOG, "prev-dialog", "^G",
+		_("Go to previous dialog"),
+		KM_NEWSBEUTER
+	},
+	{
+		OP_PIPE_TO, "pipe-to", "|",
+		_("Pipe article to command"),
+		KM_ARTICLE | KM_ARTICLELIST
+	},
+	{
+		OP_SORT, "sort", "g",
+		_("Sort current list"),
+		KM_FEEDLIST | KM_ARTICLELIST
+	},
+	{
+		OP_REVSORT, "rev-sort", "G",
+		_("Sort current list (reverse)"),
+		KM_FEEDLIST | KM_ARTICLELIST
+	},
 
-	{ OP_0,		"zero",	"0",	_("Open URL 10"), KM_URLVIEW | KM_ARTICLE },
-	{ OP_1,		"one",	"1",	_("Open URL 1"), KM_URLVIEW | KM_ARTICLE},
-	{ OP_2,		"two",	"2",	_("Open URL 2"), KM_URLVIEW | KM_ARTICLE},
-	{ OP_3,		"three","3",	_("Open URL 3"), KM_URLVIEW | KM_ARTICLE},
-	{ OP_4,		"four",	"4",	_("Open URL 4"), KM_URLVIEW | KM_ARTICLE},
-	{ OP_5,		"five",	"5",	_("Open URL 5"), KM_URLVIEW | KM_ARTICLE},
-	{ OP_6,		"six",	"6",	_("Open URL 6"), KM_URLVIEW | KM_ARTICLE},
-	{ OP_7,		"seven","7",	_("Open URL 7"), KM_URLVIEW | KM_ARTICLE},
-	{ OP_8,		"eight","8",	_("Open URL 8"), KM_URLVIEW | KM_ARTICLE},
-	{ OP_9,		"nine",	"9",	_("Open URL 9"), KM_URLVIEW | KM_ARTICLE},
+	{
+		OP_0, "zero", "0",
+		_("Open URL 10"),
+		KM_URLVIEW | KM_ARTICLE
+	},
+	{
+		OP_1, "one", "1",
+		_("Open URL 1"),
+		KM_URLVIEW | KM_ARTICLE
+	},
+	{
+		OP_2, "two", "2",
+		_("Open URL 2"),
+		KM_URLVIEW | KM_ARTICLE
+	},
+	{
+		OP_3, "three", "3",
+		_("Open URL 3"),
+		KM_URLVIEW | KM_ARTICLE
+	},
+	{
+		OP_4, "four", "4",
+		_("Open URL 4"),
+		KM_URLVIEW | KM_ARTICLE
+	},
+	{
+		OP_5, "five", "5",
+		_("Open URL 5"),
+		KM_URLVIEW | KM_ARTICLE
+	},
+	{
+		OP_6, "six", "6",
+		_("Open URL 6"),
+		KM_URLVIEW | KM_ARTICLE
+	},
+	{
+		OP_7, "seven", "7",
+		_("Open URL 7"),
+		KM_URLVIEW | KM_ARTICLE
+	},
+	{
+		OP_8, "eight", "8",
+		_("Open URL 8"),
+		KM_URLVIEW | KM_ARTICLE
+	},
+	{
+		OP_9, "nine", "9",
+		_("Open URL 9"),
+		KM_URLVIEW | KM_ARTICLE
+	},
 
-	{ OP_SK_UP, "up", "UP", _("Move to the previous entry"), KM_SYSKEYS },
-	{ OP_SK_DOWN, "down", "DOWN", _("Move to the next entry"), KM_SYSKEYS },
-	{ OP_SK_PGUP, "pageup", "PAGEUP", _("Move to the previous page"), KM_SYSKEYS },
-	{ OP_SK_PGDOWN, "pagedown", "PAGEDOWN", _("Move to the next page"), KM_SYSKEYS },
+	{
+		OP_SK_UP, "up", "UP",
+		_("Move to the previous entry"),
+		KM_SYSKEYS
+	},
+	{
+		OP_SK_DOWN, "down", "DOWN",
+		_("Move to the next entry"),
+		KM_SYSKEYS
+	},
+	{
+		OP_SK_PGUP, "pageup", "PAGEUP",
+		_("Move to the previous page"),
+		KM_SYSKEYS
+	},
+	{
+		OP_SK_PGDOWN, "pagedown", "PAGEDOWN",
+		_("Move to the next page"),
+		KM_SYSKEYS
+	},
 
-	{ OP_SK_HOME, "home", "HOME", _("Move to the start of page/list"), KM_SYSKEYS },
-	{ OP_SK_END, "end", "END", _("Move to the end of page/list"), KM_SYSKEYS },
+	{
+		OP_SK_HOME, "home", "HOME",
+		_("Move to the start of page/list"),
+		KM_SYSKEYS
+	},
+	{
+		OP_SK_END, "end", "END",
+		_("Move to the end of page/list"),
+		KM_SYSKEYS
+	},
 
-	{ OP_INT_END_QUESTION, "XXXNOKEY-end-question", "end-question", nullptr, KM_INTERNAL },
-	{ OP_INT_CANCEL_QNA, "XXXNOKEY-cancel-qna", "cancel-qna", nullptr, KM_INTERNAL },
-	{ OP_INT_QNA_NEXTHIST, "XXXNOKEY-qna-next-history", "qna-next-history", nullptr, KM_INTERNAL },
-	{ OP_INT_QNA_PREVHIST, "XXXNOKEY-qna-prev-history", "qna-prev-history", nullptr, KM_INTERNAL },
+	{
+		OP_INT_END_QUESTION, "XXXNOKEY-end-question", "end-question",
+		nullptr,
+		KM_INTERNAL
+	},
+	{
+		OP_INT_CANCEL_QNA, "XXXNOKEY-cancel-qna", "cancel-qna",
+		nullptr,
+		KM_INTERNAL
+	},
+	{
+		OP_INT_QNA_NEXTHIST, "XXXNOKEY-qna-next-history", "qna-next-history",
+		nullptr,
+		KM_INTERNAL
+	},
+	{
+		OP_INT_QNA_PREVHIST, "XXXNOKEY-qna-prev-history", "qna-prev-history",
+		nullptr,
+		KM_INTERNAL
+	},
 
-	{ OP_INT_RESIZE, "RESIZE", "internal-resize", nullptr, KM_INTERNAL },
-	{ OP_INT_SET,    "set",    "internal-set",    nullptr, KM_INTERNAL },
+	{
+		OP_INT_RESIZE, "RESIZE", "internal-resize",
+		nullptr,
+		KM_INTERNAL
+	},
+	{
+		OP_INT_SET, "set", "internal-set",
+		nullptr,
+		KM_INTERNAL
+	},
 
-	{ OP_INT_GOTO_URL, "gotourl",    "internal-goto-url",    nullptr, KM_INTERNAL },
+	{
+		OP_INT_GOTO_URL, "gotourl", "internal-goto-url",
+		nullptr,
+		KM_INTERNAL
+	},
 
 	{ OP_NIL, nullptr, nullptr, nullptr, 0 }
 };

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -23,27 +23,23 @@ static op_desc opdescs[] = {
 	{
 		OP_OPEN, "open", "ENTER",
 		_("Open feed/article"),
-		KM_FEEDLIST | KM_FILEBROWSER | KM_HELP | KM_ARTICLELIST | KM_TAGSELECT |
-			KM_FILTERSELECT | KM_URLVIEW | KM_PODBEUTER | KM_DIALOGS
+		KM_FEEDLIST | KM_FILEBROWSER | KM_ARTICLELIST | KM_TAGSELECT |
+			KM_FILTERSELECT | KM_URLVIEW | KM_DIALOGS
 	},
 	{
 		OP_QUIT, "quit", "q",
 		_("Return to previous dialog/Quit"),
-		KM_FEEDLIST | KM_FILEBROWSER | KM_HELP | KM_ARTICLELIST | KM_ARTICLE |
-			KM_TAGSELECT | KM_FILTERSELECT | KM_URLVIEW | KM_PODBEUTER |
-			KM_DIALOGS
+		KM_BOTH
 	},
 	{
 		OP_HARDQUIT, "hard-quit", "Q",
 		_("Quit program,  no confirmation"),
-		KM_FEEDLIST | KM_FILEBROWSER | KM_HELP | KM_ARTICLELIST | KM_ARTICLE |
-			KM_TAGSELECT | KM_FILTERSELECT | KM_URLVIEW | KM_PODBEUTER |
-			KM_DIALOGS
+		KM_BOTH
 	},
 	{
 		OP_RELOAD, "reload", "r",
 		_("Reload currently selected feed"),
-		KM_FEEDLIST
+		KM_FEEDLIST | KM_ARTICLELIST
 	},
 	{
 		OP_RELOADALL, "reload-all", "R",
@@ -272,11 +268,13 @@ static op_desc opdescs[] = {
 	},
 	{
 		OP_MACROPREFIX, "macro-prefix", ",",
-		_("Call a macro"), KM_NEWSBEUTER
+		_("Call a macro"),
+		KM_NEWSBEUTER
 	},
 	{
 		OP_DELETE, "delete-article", "D",
-		_("Delete article"), KM_ARTICLELIST | KM_ARTICLE
+		_("Delete article"),
+		KM_ARTICLELIST | KM_ARTICLE
 	},
 	{
 		OP_PURGE_DELETED, "purge-deleted", "$",


### PR DESCRIPTION
The width of the tab character varies from setup to setup which breaks
alignment. Using spaces is better since it has a standard length.
