### PR TITLE
Make cursor visible when in a cmdline

### DIFF
--- a/src/help_formaction.cpp
+++ b/src/help_formaction.cpp
@@ -164,6 +164,7 @@ keymap_hint_entry * help_formaction::get_keymap_hint() {
 }
 
 void help_formaction::finished_qna(operation op) {
+	v->inside_qna(false);
 	switch (op) {
 	case OP_INT_START_SEARCH:
 		searchphrase = qna_responses[0];

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -1003,6 +1003,7 @@ void view::inside_qna(bool f) {
 }
 
 void view::inside_cmdline(bool f) {
+	curs_set(f ? 1 : 0);
 	is_inside_cmdline = f;
 }
 

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -999,11 +999,11 @@ void view::goto_prev_dialog() {
 }
 
 void view::inside_qna(bool f) {
+	curs_set(f ? 1 : 0);
 	is_inside_qna = f;
 }
 
 void view::inside_cmdline(bool f) {
-	curs_set(f ? 1 : 0);
 	is_inside_cmdline = f;
 }
 


### PR DESCRIPTION
This fixes the oversight in #379.
