### PR TITLE
support xml:base in RSS 0.9x and 2.0

### DIFF
--- a/rss/atom_parser.cpp
+++ b/rss/atom_parser.cpp
@@ -93,6 +93,8 @@ item atom_parser::parse_entry(xmlNode * entryNode) {
 			if (it.description_type == "")
 				it.description_type = "text";
 			it.base = get_prop(node, "base", XML_URI);
+			if (it.base.empty())
+				it.base = base;
 		} else if (node_is(node, "id", ns)) {
 			it.guid = get_content(node);
 			it.guid_isPermaLink = false;

--- a/rss/rsspp_internal.h
+++ b/rss/rsspp_internal.h
@@ -34,6 +34,7 @@ struct rss_parser {
 		std::string w3cdtf_to_rfc822(const std::string& w3cdtf);
 		bool node_is(xmlNode * node, const char * name, const char * ns_uri = nullptr);
 		xmlDocPtr doc;
+		std::string globalbase;
 };
 
 struct rss_09x_parser : public rss_parser {
@@ -65,7 +66,6 @@ struct atom_parser : public rss_parser {
 		virtual ~atom_parser() { }
 	private:
 		item parse_entry(xmlNode * itemNode);
-		std::string globalbase;
 		const char * ns;
 };
 

--- a/test/data/atom10_1.xml
+++ b/test/data/atom10_1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en">
+<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en" xml:base="http://example.com/feed/atom_testing.html">
 <title type="text">test atom</title>
 <subtitle type="text">atom description!</subtitle>
 <id>tag:example.com</id>
@@ -16,10 +16,10 @@
 <id>tag:example.com,2008-12-30:/atom_testing</id>
 <updated>2008-12-30T20:04:15Z</updated>
 <published>2008-12-30T20:04:15Z</published>
-<content type="html" xml:base="http://example.com/atom_testing.html">some content</content>
+<content type="html">some content</content>
 </entry>
 
-<entry>
+<entry xml:base="http://example.com/entry/atom_testing.html">
 <author>
 <name>A Person</name>
 <uri>http://example.com/</uri>
@@ -29,7 +29,7 @@
 <id>tag:example.com,2008-12-30:/atom_testing1</id>
 <updated>2008-12-30T20:14:15Z</updated>
 <published>2008-12-30T20:14:15Z</published>
-<content type="html" xml:base="http://example.com/atom_testing.html">some content</content>
+<content type="html">some content</content>
 </entry>
 
 <entry>
@@ -43,6 +43,6 @@
 <id>tag:example.com,2008-12-30:/atom_testing2</id>
 <updated>2008-12-30T20:24:15Z</updated>
 <published>2008-12-30T20:24:15Z</published>
-<content type="html" xml:base="http://example.com/atom_testing.html">some content</content>
+<content type="html" xml:base="http://example.com/content/atom_testing.html">some content</content>
 </entry>
 </feed>

--- a/test/data/rss092_1.xml
+++ b/test/data/rss092_1.xml
@@ -1,4 +1,4 @@
-<rss version="0.92">
+<rss version="0.92" xml:base="http://example.com/feed/rss_testing.html">
 <channel>
 <title>Example Channel</title>
 <link>http://example.com/</link>
@@ -12,10 +12,15 @@ In HTML, <b> starts a bold phrase
 and you start a link with <a href=
 ]]></description>
 </item>
-<item>
+<item xml:base="http://example.com/item/rss_testing.html">
 <title>A second item</title>
 <link>http://example.com/a_second_item.html</link>
 <description>no description</description>
+</item>
+<item>
+<title>A third item</title>
+<link>/a_third_item.html</link>
+<description xml:base="http://example.com/desc/rss_testing.html">no description</description>
 </item>
 </channel>
 </rss>

--- a/test/rss.cpp
+++ b/test/rss.cpp
@@ -53,13 +53,23 @@ TEST_CASE("Parsers behave correctly") {
 		REQUIRE(f.link == "http://example.com/");
 		REQUIRE(f.language == "en");
 
-		REQUIRE(f.items.size() == 2u);
+		REQUIRE(f.items.size() == 3u);
+
+		REQUIRE(f.items[0].title == "1 < 2");
+		REQUIRE(f.items[0].link == "http://example.com/1_less_than_2.html");
+		REQUIRE(f.items[0].base == "http://example.com/feed/rss_testing.html");
 
 		REQUIRE(f.items[1].title == "A second item");
 		REQUIRE(f.items[1].link == "http://example.com/a_second_item.html");
 		REQUIRE(f.items[1].description == "no description");
 		REQUIRE(f.items[1].author == "");
 		REQUIRE(f.items[1].guid == "");
+		REQUIRE(f.items[1].base == "http://example.com/item/rss_testing.html");
+
+		REQUIRE(f.items[2].title == "A third item");
+		REQUIRE(f.items[2].link == "http://example.com/a_third_item.html");
+		REQUIRE(f.items[2].description == "no description");
+		REQUIRE(f.items[2].base == "http://example.com/desc/rss_testing.html");
 	}
 
 

--- a/test/rss.cpp
+++ b/test/rss.cpp
@@ -118,18 +118,21 @@ TEST_CASE("Parsers behave correctly") {
 		REQUIRE(f.items[0].link == "http://example.com/atom_testing.html");
 		REQUIRE(f.items[0].guid == "tag:example.com,2008-12-30:/atom_testing");
 		REQUIRE(f.items[0].description == "some content");
+		REQUIRE(f.items[0].base == "http://example.com/feed/atom_testing.html");
 
 		REQUIRE(f.items[1].title == "A missing rel attribute");
 		REQUIRE(f.items[1].title_type == "html");
 		REQUIRE(f.items[1].link == "http://example.com/atom_testing.html");
 		REQUIRE(f.items[1].guid == "tag:example.com,2008-12-30:/atom_testing1");
 		REQUIRE(f.items[1].description == "some content");
+		REQUIRE(f.items[1].base == "http://example.com/entry/atom_testing.html");
 
 		REQUIRE(f.items[2].title == "alternate link isn't first");
 		REQUIRE(f.items[2].title_type == "html");
 		REQUIRE(f.items[2].link == "http://example.com/atom_testing.html");
 		REQUIRE(f.items[2].guid == "tag:example.com,2008-12-30:/atom_testing2");
 		REQUIRE(f.items[2].description == "some content");
+		REQUIRE(f.items[2].base == "http://example.com/content/atom_testing.html");
 	}
 }
 


### PR DESCRIPTION
Hi,

the atom parser (mostly) supports an xml:base attribute being used to define the base-path for relative links in the entries. This pull-request "copies" this support to the RSS 0.9x and by extend 2.0 (aka: I haven't tried implementing it in RSS 1.0) fixing atom in the process and extending the tests slightly.

The usage of the attribute (and relative links) isn't very common I guess, but e.g. tweeper (https://git.ao2.it/tweeper.git/) generates RSS feeds with it and atom was already supporting it so it shouldn't be entirely useless, "just" obscure as a feature.

Lightly tested with my feeds to not crash and burn instantly (or after a few feed reloads), but I have no prior experience with newsbeuter-code, so there might be gotchas. You have been warned.

Thanks for considering & best regards

David Kalnischkies