### PR TITLE
Fix table alignment & wrapping

### DIFF
--- a/include/htmlrenderer.h
+++ b/include/htmlrenderer.h
@@ -85,7 +85,10 @@ class htmlrenderer {
 				const std::string& curline,
 				std::vector<Table>& tables,
 				std::vector<std::pair<LineType, std::string>>& lines);
-		void add_line_verbatim(
+		void add_line_softwrappable(
+				const std::string& line,
+				std::vector<std::pair<LineType, std::string>>& lines);
+		void add_line_nonwrappable(
 				const std::string& line,
 				std::vector<std::pair<LineType, std::string>>& lines);
 		void add_hr(std::vector<std::pair<LineType, std::string>>& lines);

--- a/include/textformatter.h
+++ b/include/textformatter.h
@@ -9,8 +9,21 @@
 
 namespace newsbeuter {
 
+/*
+ * LineType specifies the way wrapping should be handled.
+ *
+ * wrappable: Wrap lines at the user-specified text-width setting, if not set
+ * wrap at the window border.
+ *
+ * softwrappable: Wrap at the window border
+ *
+ * nonwrappable: Don't wrap lines, characters that cannot be drawn due to
+ *               insufficient window width will be ignored.
+ */
+
 enum LineType {
 	wrappable = 1,
+	softwrappable,
 	nonwrappable,
 	hr
 };

--- a/include/textformatter.h
+++ b/include/textformatter.h
@@ -41,7 +41,7 @@ class textformatter {
 				const std::string& location = "",
 				const size_t wrap_width = 80,
 				const size_t total_width = 0);
-		std::string format_text_plain(const size_t width = 80);
+		std::string format_text_plain(const size_t width = 80, const size_t total_width = 0);
 
 		inline void clear() {
 			lines.clear();

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -1424,12 +1424,12 @@ void controller::write_item(std::shared_ptr<rss_item> item, std::ostream& ostr) 
 
 	std::string link(_("Link: "));
 	link.append(item->link());
-	lines.push_back(std::make_pair(newsbeuter::nonwrappable, link));
+	lines.push_back(std::make_pair(newsbeuter::softwrappable, link));
 
 	if (item->enclosure_url() != "") {
 		std::string dlurl(_("Podcast Download URL: "));
 		dlurl.append(item->enclosure_url());
-		lines.push_back(std::make_pair(newsbeuter::nonwrappable, dlurl));
+		lines.push_back(std::make_pair(newsbeuter::softwrappable, dlurl));
 	}
 
 	lines.push_back(std::make_pair(newsbeuter::wrappable, std::string("")));

--- a/src/htmlrenderer.cpp
+++ b/src/htmlrenderer.cpp
@@ -532,7 +532,7 @@ void htmlrenderer::render(
 							std::string s = table_text[idx].second;
 							while (s.length() > 0 && s[0] == '\n')
 								s.erase(0, 1);
-							add_line(s, tables, lines);
+							add_line_nonwrappable(s, lines);
 						}
 					}
 				}
@@ -628,7 +628,7 @@ void htmlrenderer::render(
 			std::string s = table_text[idx].second;
 			while (s.length() > 0 && s[0] == '\n')
 				s.erase(0, 1);
-			add_line(s, tables, lines);
+			add_line_nonwrappable(s, lines);
 		}
 	}
 
@@ -822,7 +822,7 @@ void htmlrenderer::render_table(
 
 	// render the table
 	if (table.border)
-		lines.push_back(std::make_pair(newsbeuter::softwrappable, separator));
+		lines.push_back(std::make_pair(newsbeuter::nonwrappable, separator));
 	for (size_t row=0; row < rows; row++) {
 		// calc height of this row
 		size_t height = 0;
@@ -854,10 +854,10 @@ void htmlrenderer::render_table(
 			}
 			if (table.border)
 				line += vsep;
-			lines.push_back(std::make_pair(newsbeuter::softwrappable, line));
+			lines.push_back(std::make_pair(newsbeuter::nonwrappable, line));
 		}
 		if (table.border)
-			lines.push_back(std::make_pair(newsbeuter::softwrappable, separator));
+			lines.push_back(std::make_pair(newsbeuter::nonwrappable, separator));
 	}
 }
 

--- a/src/htmlrenderer.cpp
+++ b/src/htmlrenderer.cpp
@@ -456,7 +456,7 @@ void htmlrenderer::render(
 				break;
 
 			case TAG_PRE:
-				add_line_verbatim(curline, lines);
+				add_line_softwrappable(curline, lines);
 				prepare_new_line(curline,  tables.size() ? 0 : indent_level);
 				inside_pre = false;
 				break;
@@ -586,7 +586,7 @@ void htmlrenderer::render(
 				std::vector<std::string> paragraphs = utils::tokenize_nl(text);
 				for (auto paragraph : paragraphs) {
 					if (paragraph == "\n") {
-						add_line_verbatim(curline, lines);
+						add_line_softwrappable(curline, lines);
 						prepare_new_line(curline,  tables.size() ? 0 : indent_level);
 					} else {
 						curline.append(paragraph);
@@ -642,7 +642,7 @@ void htmlrenderer::render(
 					i+1,
 					links[i].first.c_str(),
 					type2str(links[i].second).c_str());
-			lines.push_back(std::make_pair(newsbeuter::nonwrappable, link_text));
+			lines.push_back(std::make_pair(newsbeuter::softwrappable, link_text));
 		}
 	}
 }
@@ -692,7 +692,14 @@ void htmlrenderer::add_line(
 		lines.push_back(std::make_pair(newsbeuter::wrappable, curline));
 }
 
-void htmlrenderer::add_line_verbatim(
+void htmlrenderer::add_line_softwrappable(
+		const std::string& line,
+		std::vector<std::pair<LineType, std::string>>& lines)
+{
+	lines.push_back(std::make_pair(newsbeuter::softwrappable, line));
+}
+
+void htmlrenderer::add_line_nonwrappable(
 		const std::string& line,
 		std::vector<std::pair<LineType, std::string>>& lines)
 {
@@ -815,7 +822,7 @@ void htmlrenderer::render_table(
 
 	// render the table
 	if (table.border)
-		lines.push_back(std::make_pair(newsbeuter::nonwrappable, separator));
+		lines.push_back(std::make_pair(newsbeuter::softwrappable, separator));
 	for (size_t row=0; row < rows; row++) {
 		// calc height of this row
 		size_t height = 0;
@@ -847,10 +854,10 @@ void htmlrenderer::render_table(
 			}
 			if (table.border)
 				line += vsep;
-			lines.push_back(std::make_pair(newsbeuter::nonwrappable, line));
+			lines.push_back(std::make_pair(newsbeuter::softwrappable, line));
 		}
 		if (table.border)
-			lines.push_back(std::make_pair(newsbeuter::nonwrappable, separator));
+			lines.push_back(std::make_pair(newsbeuter::softwrappable, separator));
 	}
 }
 

--- a/src/htmlrenderer.cpp
+++ b/src/htmlrenderer.cpp
@@ -642,7 +642,7 @@ void htmlrenderer::render(
 					i+1,
 					links[i].first.c_str(),
 					type2str(links[i].second).c_str());
-			lines.push_back(std::make_pair(newsbeuter::softwrappable, link_text));
+			add_line_softwrappable(link_text, lines);
 		}
 	}
 }

--- a/src/itemview_formaction.cpp
+++ b/src/itemview_formaction.cpp
@@ -83,7 +83,7 @@ void itemview_formaction::prepare() {
 
 		if (item->link().length() > 0) {
 			std::string link = utils::strprintf("%s%s", _("Link: "), utils::censor_url(item->link()).c_str());
-			textfmt.add_line(newsbeuter::nonwrappable, link);
+			textfmt.add_line(newsbeuter::softwrappable, link);
 		}
 
 		std::string date = utils::strprintf("%s%s", _("Date: "), item->pubDate().c_str());
@@ -99,7 +99,7 @@ void itemview_formaction::prepare() {
 			if (item->enclosure_type() != "") {
 				enc_url.append(utils::strprintf(" (%s%s)",  _("type: "), item->enclosure_type().c_str()));
 			}
-			textfmt.add_line(newsbeuter::nonwrappable, enc_url);
+			textfmt.add_line(newsbeuter::softwrappable, enc_url);
 		}
 
 		textfmt.add_line(newsbeuter::wrappable, std::string());
@@ -445,7 +445,7 @@ void itemview_formaction::render_source(
 			source.erase();
 		else
 			source.erase(0, pos+1);
-		lines.push_back(std::make_pair(nonwrappable, line));
+		lines.push_back(std::make_pair(softwrappable, line));
 	} while (source.length() > 0);
 }
 
@@ -543,7 +543,7 @@ std::vector<std::pair<LineType, std::string>>
 		std::string line;
 		getline(is, line);
 		while (!is.eof()) {
-			result.push_back(std::make_pair(newsbeuter::nonwrappable, utils::quote_for_stfl(line)));
+			result.push_back(std::make_pair(newsbeuter::softwrappable, utils::quote_for_stfl(line)));
 			getline(is, line);
 		}
 	}

--- a/src/textformatter.cpp
+++ b/src/textformatter.cpp
@@ -82,7 +82,7 @@ std::string format_text_plain_helper(
 		const std::string& location,
 		// wrappable lines are wrapped at this width
 		const size_t wrap_width,
-		// if non-zero, nonwrappable lines are wrapped at this width
+		// if non-zero, softwrappable lines are wrapped at this width
 		const size_t total_width)
 {
 	LOG(LOG_DEBUG,
@@ -119,7 +119,7 @@ std::string format_text_plain_helper(
 				}
 				break;
 
-			case nonwrappable:
+			case softwrappable:
 				if (total_width == 0) {
 					store_line(text);
 				} else {
@@ -127,6 +127,10 @@ std::string format_text_plain_helper(
 						store_line(line);
 					}
 				}
+				break;
+
+			case nonwrappable:
+				store_line(text);
 				break;
 
 			case hr:

--- a/src/textformatter.cpp
+++ b/src/textformatter.cpp
@@ -167,8 +167,8 @@ std::string textformatter::format_text_to_list(
 	return format_cache;
 }
 
-std::string textformatter::format_text_plain(const size_t width) {
-	return format_text_plain_helper(lines, nullptr, std::string(), width, 0);
+std::string textformatter::format_text_plain(const size_t width, const size_t total_width) {
+	return format_text_plain_helper(lines, nullptr, std::string(), width, total_width);
 }
 
 }

--- a/test/htmlrenderer.cpp
+++ b/test/htmlrenderer.cpp
@@ -802,7 +802,7 @@ TEST_CASE("htmlrenderer: header rows of tables are in bold") {
 
 		REQUIRE_NOTHROW(r.render(input, lines, links, url));
 		REQUIRE(lines.size() == 1);
-		REQUIRE(lines[0] == p(wrappable, "<b>header</>"));
+		REQUIRE(lines[0] == p(nonwrappable, "<b>header</>"));
 		REQUIRE(links.size() == 0);
 	}
 
@@ -817,7 +817,7 @@ TEST_CASE("htmlrenderer: header rows of tables are in bold") {
 
 		REQUIRE_NOTHROW(r.render(input, lines, links, url));
 		REQUIRE(lines.size() == 1);
-		REQUIRE(lines[0] == p(wrappable, "<b>another</> <b>header</>"));
+		REQUIRE(lines[0] == p(nonwrappable, "<b>another</> <b>header</>"));
 		REQUIRE(links.size() == 0);
 	}
 }
@@ -837,7 +837,7 @@ TEST_CASE("htmlrenderer: cells are separated by space if `border' is not set") {
 
 	REQUIRE_NOTHROW(r.render(input, lines, links, url));
 	REQUIRE(lines.size() == 1);
-	REQUIRE(lines[0] == p(wrappable, "hello world"));
+	REQUIRE(lines[0] == p(nonwrappable, "hello world"));
 	REQUIRE(links.size() == 0);
 }
 
@@ -860,7 +860,7 @@ TEST_CASE("htmlrenderer: cells are separated by vertical bar if `border' is set 
 
 		REQUIRE_NOTHROW(r.render(input, lines, links, url));
 		REQUIRE(lines.size() == 3);
-		REQUIRE(lines[1] == p(wrappable, "|hello|world|"));
+		REQUIRE(lines[1] == p(nonwrappable, "|hello|world|"));
 		REQUIRE(links.size() == 0);
 		}
 	}
@@ -881,9 +881,9 @@ TEST_CASE("htmlrenderer: tables with `border' have borders") {
 
 	REQUIRE_NOTHROW(r.render(input, lines, links, url));
 	REQUIRE(lines.size() == 3);
-	REQUIRE(lines[0] == p(wrappable, "+-----+-----+"));
-	REQUIRE(lines[1] == p(wrappable, "|hello|world|"));
-	REQUIRE(lines[2] == p(wrappable, "+-----+-----+"));
+	REQUIRE(lines[0] == p(nonwrappable, "+-----+-----+"));
+	REQUIRE(lines[1] == p(nonwrappable, "|hello|world|"));
+	REQUIRE(lines[2] == p(nonwrappable, "+-----+-----+"));
 	REQUIRE(links.size() == 0);
 }
 
@@ -901,9 +901,9 @@ TEST_CASE("htmlrenderer: if document ends before </table> is found, table is ren
 
 	REQUIRE_NOTHROW(r.render(input, lines, links, url));
 	REQUIRE(lines.size() == 3);
-	REQUIRE(lines[0] == p(wrappable, "+-----+-----+"));
-	REQUIRE(lines[1] == p(wrappable, "|hello|world|"));
-	REQUIRE(lines[2] == p(wrappable, "+-----+-----+"));
+	REQUIRE(lines[0] == p(nonwrappable, "+-----+-----+"));
+	REQUIRE(lines[1] == p(nonwrappable, "|hello|world|"));
+	REQUIRE(lines[2] == p(nonwrappable, "+-----+-----+"));
 	REQUIRE(links.size() == 0);
 }
 
@@ -933,13 +933,13 @@ TEST_CASE("htmlrenderer: tables can be nested") {
 
 	REQUIRE_NOTHROW(r.render(input, lines, links, url));
 	REQUIRE(lines.size() == 7);
-	REQUIRE(lines[0] == p(wrappable, "+---------------+-----------+"));
-	REQUIRE(lines[1] == p(wrappable, "|+-------+-----+|lonely cell|"));
-	REQUIRE(lines[2] == p(wrappable, "||hello  |world||           |"));
-	REQUIRE(lines[3] == p(wrappable, "|+-------+-----+|           |"));
-	REQUIRE(lines[4] == p(wrappable, "||another|row  ||           |"));
-	REQUIRE(lines[5] == p(wrappable, "|+-------+-----+|           |"));
-	REQUIRE(lines[6] == p(wrappable, "+---------------+-----------+"));
+	REQUIRE(lines[0] == p(nonwrappable, "+---------------+-----------+"));
+	REQUIRE(lines[1] == p(nonwrappable, "|+-------+-----+|lonely cell|"));
+	REQUIRE(lines[2] == p(nonwrappable, "||hello  |world||           |"));
+	REQUIRE(lines[3] == p(nonwrappable, "|+-------+-----+|           |"));
+	REQUIRE(lines[4] == p(nonwrappable, "||another|row  ||           |"));
+	REQUIRE(lines[5] == p(nonwrappable, "|+-------+-----+|           |"));
+	REQUIRE(lines[6] == p(nonwrappable, "+---------------+-----------+"));
 
 	REQUIRE(links.size() == 0);
 }
@@ -958,9 +958,9 @@ TEST_CASE("htmlrenderer: if <td> appears inside table but outside of a row, one 
 
 	REQUIRE_NOTHROW(r.render(input, lines, links, url));
 	REQUIRE(lines.size() == 3);
-	REQUIRE(lines[0] == p(wrappable, "+-----+-----+"));
-	REQUIRE(lines[1] == p(wrappable, "|hello|world|"));
-	REQUIRE(lines[2] == p(wrappable, "+-----+-----+"));
+	REQUIRE(lines[0] == p(nonwrappable, "+-----+-----+"));
+	REQUIRE(lines[1] == p(nonwrappable, "|hello|world|"));
+	REQUIRE(lines[2] == p(nonwrappable, "+-----+-----+"));
 	REQUIRE(links.size() == 0);
 }
 
@@ -977,11 +977,11 @@ TEST_CASE("htmlrenderer: previous row is implicitly closed when <tr> is found") 
 
 	REQUIRE_NOTHROW(r.render(input, lines, links, url));
 	REQUIRE(lines.size() == 5);
-	REQUIRE(lines[0] == p(wrappable, "+-----+"));
-	REQUIRE(lines[1] == p(wrappable, "|hello|"));
-	REQUIRE(lines[2] == p(wrappable, "+-----+"));
-	REQUIRE(lines[3] == p(wrappable, "|world|"));
-	REQUIRE(lines[4] == p(wrappable, "+-----+"));
+	REQUIRE(lines[0] == p(nonwrappable, "+-----+"));
+	REQUIRE(lines[1] == p(nonwrappable, "|hello|"));
+	REQUIRE(lines[2] == p(nonwrappable, "+-----+"));
+	REQUIRE(lines[3] == p(nonwrappable, "|world|"));
+	REQUIRE(lines[4] == p(nonwrappable, "+-----+"));
 	REQUIRE(links.size() == 0);
 }
 
@@ -999,9 +999,9 @@ TEST_CASE("htmlrenderer: free-standing text outside of <td> is implicitly concat
 
 	REQUIRE_NOTHROW(r.render(input, lines, links, url));
 	REQUIRE(lines.size() == 3);
-	REQUIRE(lines[0] == p(wrappable, "+-----------+"));
-	REQUIRE(lines[1] == p(wrappable, "|hello world|"));
-	REQUIRE(lines[2] == p(wrappable, "+-----------+"));
+	REQUIRE(lines[0] == p(nonwrappable, "+-----------+"));
+	REQUIRE(lines[1] == p(nonwrappable, "|hello world|"));
+	REQUIRE(lines[2] == p(nonwrappable, "+-----------+"));
 	REQUIRE(links.size() == 0);
 }
 

--- a/test/htmlrenderer.cpp
+++ b/test/htmlrenderer.cpp
@@ -35,6 +35,8 @@ namespace Catch {
 		switch(value) {
 			case wrappable:
 				return "wrappable";
+			case softwrappable:
+				return "softwrappable";
 			case nonwrappable:
 				return "nonwrappable";
 			case hr:
@@ -77,7 +79,7 @@ TEST_CASE("HTMLRenderer behaves correctly") {
 		REQUIRE(lines[0] == p(wrappable, "<u>slashdot</>[1]"));
 		REQUIRE(lines[1] == p(wrappable, ""));
 		REQUIRE(lines[2] == p(wrappable, "Links: "));
-		REQUIRE(lines[3] == p(nonwrappable, "[1]: http://slashdot.org/ (link)"));
+		REQUIRE(lines[3] == p(softwrappable, "[1]: http://slashdot.org/ (link)"));
 
 		REQUIRE(links[0].first == "http://slashdot.org/");
 		REQUIRE(links[0].second == LINK_HREF);
@@ -263,7 +265,7 @@ TEST_CASE("htmlrenderer: Flash <embed>s are added to links if `src' is set") {
 	REQUIRE(lines[0] == p(wrappable, "[embedded flash: 1]"));
 	REQUIRE(lines[1] == p(wrappable, ""));
 	REQUIRE(lines[2] == p(wrappable, "Links: "));
-	REQUIRE(lines[3] == p(nonwrappable, "[1]: http://example.com/game.swf (embedded flash)"));
+	REQUIRE(lines[3] == p(softwrappable, "[1]: http://example.com/game.swf (embedded flash)"));
 	REQUIRE(links.size() == 1);
 	REQUIRE(links[0].first == "http://example.com/game.swf");
 	REQUIRE(links[0].second == LINK_EMBED);
@@ -321,8 +323,8 @@ TEST_CASE("htmlrenderer: spaces and line breaks are preserved inside <pre>") {
 
 	REQUIRE_NOTHROW(r.render(input, lines, links, url));
 	REQUIRE(lines.size() == 2);
-	REQUIRE(lines[0] == p(nonwrappable, "oh cool"));
-	REQUIRE(lines[1] == p(nonwrappable, "  check this\tstuff  out!"));
+	REQUIRE(lines[0] == p(softwrappable, "oh cool"));
+	REQUIRE(lines[1] == p(softwrappable, "  check this\tstuff  out!"));
 	REQUIRE(links.size() == 0);
 }
 
@@ -339,7 +341,7 @@ TEST_CASE("htmlrenderer: tags still work inside <pre>") {
 
 	REQUIRE_NOTHROW(r.render(input, lines, links, url));
 	REQUIRE(lines.size() == 1);
-	REQUIRE(lines[0] == p(nonwrappable, "<b>bold text</><u>underlined text</>"));
+	REQUIRE(lines[0] == p(softwrappable, "<b>bold text</><u>underlined text</>"));
 	REQUIRE(links.size() == 0);
 }
 
@@ -356,7 +358,7 @@ TEST_CASE("htmlrenderer: <img> results in a placeholder and a link") {
 	REQUIRE(lines[0] == p(wrappable, "[image 1]"));
 	REQUIRE(lines[1] == p(wrappable, ""));
 	REQUIRE(lines[2] == p(wrappable, "Links: "));
-	REQUIRE(lines[3] == p(nonwrappable, "[1]: http://example.com/image.png (image)"));
+	REQUIRE(lines[3] == p(softwrappable, "[1]: http://example.com/image.png (image)"));
 	REQUIRE(links.size() == 1);
 	REQUIRE(links[0].first == "http://example.com/image.png");
 	REQUIRE(links[0].second == LINK_IMG);
@@ -389,7 +391,7 @@ TEST_CASE("htmlrenderer: title is mentioned in placeholder if <img> has `title'"
 	REQUIRE(lines[0] == p(wrappable, "[image 1: Just a test image]"));
 	REQUIRE(lines[1] == p(wrappable, ""));
 	REQUIRE(lines[2] == p(wrappable, "Links: "));
-	REQUIRE(lines[3] == p(nonwrappable, "[1]: http://example.com/image.png (image)"));
+	REQUIRE(lines[3] == p(softwrappable, "[1]: http://example.com/image.png (image)"));
 	REQUIRE(links.size() == 1);
 	REQUIRE(links[0].first == "http://example.com/image.png");
 	REQUIRE(links[0].second == LINK_IMG);
@@ -410,7 +412,7 @@ TEST_CASE("htmlrenderer: URL of <img> with data inside `src' is replaced with st
 	REQUIRE(lines[0] == p(wrappable, "[image 1]"));
 	REQUIRE(lines[1] == p(wrappable, ""));
 	REQUIRE(lines[2] == p(wrappable, "Links: "));
-	REQUIRE(lines[3] == p(nonwrappable, "[1]: inline image (image)"));
+	REQUIRE(lines[3] == p(softwrappable, "[1]: inline image (image)"));
 	REQUIRE(links.size() == 1);
 	REQUIRE(links[0].first == "inline image");
 	REQUIRE(links[0].second == LINK_IMG);

--- a/test/textformatter.cpp
+++ b/test/textformatter.cpp
@@ -10,7 +10,8 @@ TEST_CASE("textformatter: lines marked as `wrappable` are wrapped to fit width")
 	fmt.add_lines(
 		{
 			std::make_pair(wrappable, "this one is going to be wrapped"),
-			std::make_pair(softwrappable, "this one is going to be preserved")
+			std::make_pair(softwrappable, "this one is going to be wrapped at the window border"),
+			std::make_pair(nonwrappable, "this one is going to be preserved even though it's much longer")
 		});
 
 	SECTION("formatting to plain text") {
@@ -19,8 +20,10 @@ TEST_CASE("textformatter: lines marked as `wrappable` are wrapped to fit width")
 			"is going \n"
 			"to be \n"
 			"wrapped\n"
-			"this one is going to be preserved\n";
-		REQUIRE(fmt.format_text_plain(10) == expected);
+			"this one is going to be wrapped at the \n"
+			"window border\n"
+			"this one is going to be preserved even though it's much longer\n";
+		REQUIRE(fmt.format_text_plain(10, 40) == expected);
 	}
 
 	SECTION("formatting to list") {
@@ -30,9 +33,11 @@ TEST_CASE("textformatter: lines marked as `wrappable` are wrapped to fit width")
 				"{listitem text:\"is going \"}"
 				"{listitem text:\"to be \"}"
 				"{listitem text:\"wrapped\"}"
-				"{listitem text:\"this one is going to be preserved\"}"
+				"{listitem text:\"this one is going to be wrapped at the \"}"
+				"{listitem text:\"window border\"}"
+				"{listitem text:\"this one is going to be preserved even though it's much longer\"}"
 			"}";
-		REQUIRE(fmt.format_text_to_list(nullptr, "", 10) == expected);
+		REQUIRE(fmt.format_text_to_list(nullptr, "", 10, 40) == expected);
 	}
 }
 
@@ -71,14 +76,19 @@ TEST_CASE("textformatter: <hr> is rendered properly") {
 
 TEST_CASE("textformatter: wrappable sequences longer then format width are forced-wrapped") {
 	textformatter fmt;
-	fmt.add_line(wrappable, "0123456789");
-	fmt.add_line(softwrappable, "0123456789");
+	fmt.add_line(wrappable, "0123456789101112");
+	fmt.add_line(softwrappable, "0123456789101112");
+	fmt.add_line(nonwrappable, "0123456789101112");
 
 	const std::string expected =
 		"01234\n"
 		"56789\n"
-		"0123456789\n";
-	REQUIRE(fmt.format_text_plain(5) == expected);
+		"10111\n"
+		"2\n"
+		"0123456789\n"
+		"101112\n"
+		"0123456789101112\n";
+	REQUIRE(fmt.format_text_plain(5, 10) == expected);
 }
 
 TEST_CASE("textformatter: when wrapping, spaces at the beginning of lines are dropped") {

--- a/test/textformatter.cpp
+++ b/test/textformatter.cpp
@@ -10,7 +10,7 @@ TEST_CASE("textformatter: lines marked as `wrappable` are wrapped to fit width")
 	fmt.add_lines(
 		{
 			std::make_pair(wrappable, "this one is going to be wrapped"),
-			std::make_pair(nonwrappable, "this one is going to be preserved")
+			std::make_pair(softwrappable, "this one is going to be preserved")
 		});
 
 	SECTION("formatting to plain text") {
@@ -72,7 +72,7 @@ TEST_CASE("textformatter: <hr> is rendered properly") {
 TEST_CASE("textformatter: wrappable sequences longer then format width are forced-wrapped") {
 	textformatter fmt;
 	fmt.add_line(wrappable, "0123456789");
-	fmt.add_line(nonwrappable, "0123456789");
+	fmt.add_line(softwrappable, "0123456789");
 
 	const std::string expected =
 		"01234\n"
@@ -92,9 +92,9 @@ TEST_CASE("textformatter: when wrapping, spaces at the beginning of lines are dr
 	REQUIRE(fmt.format_text_plain(4) == expected);
 }
 
-TEST_CASE("textformatter: nonwrappable lines are wrapped by format_text_to_list if total_width != 0") {
+TEST_CASE("textformatter: softwrappable lines are wrapped by format_text_to_list if total_width != 0") {
 	textformatter fmt;
-	fmt.add_line(nonwrappable, "just a test");
+	fmt.add_line(softwrappable, "just a test");
 	const size_t wrap_width = 100;
 	regexmanager * rxman = nullptr;
 	const std::string location = "";


### PR DESCRIPTION
This PR fixes 2 issues with line wrapping:
* `nonwrappable` line types still got wrapped at the screen border which made the name misleading and offered no real way to disable wrapping entirely. Fixed this by renaming the current functionality to `softwrappable` and introducing `nonwrappable` which passes the text without wrapping or any other operations.

* HTML tables were marked as wrappable when they shouldn't be.