### PR TITLE
Don't allow query feeds to be opened in browser

### DIFF
--- a/src/feedlist_formaction.cpp
+++ b/src/feedlist_formaction.cpp
@@ -158,8 +158,12 @@ REDO:
 		if (feeds_shown > 0 && feedpos.length() > 0) {
 			std::shared_ptr<rss_feed> feed = v->get_ctrl()->get_feed(pos);
 			if (feed) {
-				LOG(LOG_INFO, "feedlist_formaction: opening feed at position `%s': %s", feedpos.c_str(), feed->link().c_str());
-				v->open_in_browser(feed->link());
+				if (feed->rssurl().substr(0,6) != "query:") {
+					LOG(LOG_INFO, "feedlist_formaction: opening feed at position `%s': %s", feedpos.c_str(), feed->link().c_str());
+					v->open_in_browser(feed->link());
+				} else {
+					v->show_error(_("Cannot open query feeds in the browser!"));
+				}
 			}
 		} else {
 			v->show_error(_("No feed selected!"));


### PR DESCRIPTION
Query feeds only exist in memory, if open-in-browser was called on a query feed
it would simply open a browser to the users home directory, which is obviously
erroneous behaviour.