### PR TITLE
Support for delta feeds (RFC3229+feed)

### DIFF
--- a/rss/parser.cpp
+++ b/rss/parser.cpp
@@ -127,6 +127,7 @@ feed parser::parse_url(const std::string& url, time_t lastmodified, const std::s
 	if (etag.length() > 0) {
 		auto header = utils::strprintf("If-None-Match: %s", etag.c_str());
 		custom_headers = curl_slist_append(custom_headers, header.c_str());
+		custom_headers = curl_slist_append(custom_headers, "A-IM: feed");
 	}
 
 	if (custom_headers) {


### PR DESCRIPTION
The `If-None-Match` header combined with the `A-IM: feed` header instructs
compatible servers to only send the feed entries that have been added or
changed since the feed was last updated. (As determined using the ETag sent
by the server which is later returned by the If-None-Match header.)

No other changes required than adding this header. Supported by ExpressionEngine, Textpattern, and Liferea. I’m working on adding support to all the major open source feed readers, and will submit patches to WordPress as well.