### PR TITLE
Send A-IM header with either etag or lastmod

### DIFF
--- a/rss/parser.cpp
+++ b/rss/parser.cpp
@@ -127,6 +127,9 @@ feed parser::parse_url(const std::string& url, time_t lastmodified, const std::s
 	if (etag.length() > 0) {
 		auto header = utils::strprintf("If-None-Match: %s", etag.c_str());
 		custom_headers = curl_slist_append(custom_headers, header.c_str());
+	}
+
+	if (lastmodified != 0 || etag.length() > 0) {
 		custom_headers = curl_slist_append(custom_headers, "A-IM: feed");
 	}
 


### PR DESCRIPTION
I did a mistake with pull request #390. The header should be sent if either If-None-Match or/and If-Last-Modified headers are also sent to match other implementations.