### PR TITLE
Include the git commit hash in the version macro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,12 @@ CXX?=c++
 
 # compiler and linker flags
 DEFINES=-DLOCALEDIR=\"$(localedir)\"
+
+ifneq ($(wildcard .git/.),)
+GIT_HASH=$(shell git describe --abbrev=4 --dirty --always --tags)
+DEFINES+=-DGIT_HASH=\"$(GIT_HASH)\"
+endif
+
 WARNFLAGS=-Wall -Wextra -Wunreachable-code
 BARE_CXXFLAGS=-std=c++11 -ggdb -Iinclude -Istfl -Ifilter -I. -Irss
 CXXFLAGS+=$(BARE_CXXFLAGS) $(WARNFLAGS) $(DEFINES)

--- a/config.h
+++ b/config.h
@@ -3,7 +3,14 @@
 
 #define PACKAGE				"newsbeuter"
 #define PROGRAM_NAME			PACKAGE
-#define PROGRAM_VERSION			"2.10"
+#define REAL_VERSION "2.10"
+
+#ifdef GIT_HASH
+#define PROGRAM_VERSION			REAL_VERSION "-" GIT_HASH
+#else
+#define PROGRAM_VERSION			REAL_VERSION
+#endif
+
 #define PROGRAM_URL			"http://www.newsbeuter.org/"
 
 #define NEWSBEUTER_PATH_SEP			"/"


### PR DESCRIPTION
Include the commit hash in the version if built from git to ease debugging.