### PR TITLE
Don't use make_parents with the filename

### DIFF
--- a/src/poddlthread.cpp
+++ b/src/poddlthread.cpp
@@ -59,7 +59,9 @@ void poddlthread::run() {
 
 	if (stat(dl->filename().c_str(), &sb) == -1) {
 		LOG(level::INFO, "poddlthread::run: stat failed: starting normal download");
-		utils::mkdir_parents(dl->filename());
+		std::string filename = dl->filename();
+		std::vector<char> directory(filename.begin(), filename.end());
+		utils::mkdir_parents(dirname(&directory[0]));
 		f->open(dl->filename().c_str(), std::fstream::out);
 		dl->set_offset(0);
 		resumed_download = false;


### PR DESCRIPTION
Previously, we were using a, now removed, function called mkdir_p to
create the directories for the podbeuter download. That function had a
bug(or was it a feature?) that always ignored the last part of the path.
This worked with the current setup well since it was only passed paths
that included a filename that should be ignored when created the
directories anyway.

In f1dd88e4a4e31c5945a12cbbef6d99df28cad67d it was changed to use
mkdir_parents and mkdir_p was removed. This caused all the files
podbeuter was trying to download to be created as directories instead of
regular files, causing all subsequent attempts to write to them to fail.