### PR TITLE
Separate line wrapping and whitespace consolidation

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -42,6 +42,8 @@ class utils {
 		static std::vector<std::string> tokenize_nl(const std::string& str, std::string delimiters = "\r\n");
 		static std::vector<std::string> tokenize_quoted(const std::string& str, std::string delimiters = " \r\n\t");
 
+		static std::string consolidate_whitespace(const std::string& str, std::string whitespace = " \r\n\t");
+
 		static std::vector<std::wstring> wtokenize(const std::wstring& str, std::wstring delimiters = L" \r\n\t");
 
 		static bool try_fs_lock(const std::string& lock_file, pid_t & pid);

--- a/src/textformatter.cpp
+++ b/src/textformatter.cpp
@@ -115,6 +115,7 @@ std::string format_text_plain_helper(
 
 		switch(type) {
 			case LineType::wrappable:
+				text = utils::consolidate_whitespace(text);
 				for (auto line : wrap_line(text, wrap_width)) {
 					store_line(line);
 				}

--- a/src/textformatter.cpp
+++ b/src/textformatter.cpp
@@ -115,6 +115,10 @@ std::string format_text_plain_helper(
 
 		switch(type) {
 			case LineType::wrappable:
+				if(text == "") {
+					store_line(" ");
+					continue;
+				}
 				text = utils::consolidate_whitespace(text);
 				for (auto line : wrap_line(text, wrap_width)) {
 					store_line(line);
@@ -122,6 +126,10 @@ std::string format_text_plain_helper(
 				break;
 
 			case LineType::softwrappable:
+				if(text == "") {
+					store_line(" ");
+					continue;
+				}
 				if (total_width == 0) {
 					store_line(text);
 				} else {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -177,18 +177,38 @@ std::vector<std::string> utils::tokenize_spaced(const std::string& str, std::str
 	std::string::size_type pos = str.find_first_of(delimiters, last_pos);
 
 	if (last_pos != 0) {
-		tokens.push_back(std::string(" "));
+		tokens.push_back(str.substr(0, last_pos));
 	}
 
 	while (std::string::npos != pos || std::string::npos != last_pos) {
 		tokens.push_back(str.substr(last_pos, pos - last_pos));
 		last_pos = str.find_first_not_of(delimiters, pos);
 		if (last_pos > pos)
-			tokens.push_back(std::string(" "));
+			tokens.push_back(str.substr(pos, last_pos - pos));
 		pos = str.find_first_of(delimiters, last_pos);
 	}
 
 	return tokens;
+}
+
+std::string utils::consolidate_whitespace(const std::string& str, std::string whitespace) {
+	std::string result;
+	std::string::size_type last_pos = str.find_first_not_of(whitespace, 0);
+	std::string::size_type pos = str.find_first_of(whitespace, last_pos);
+
+	if(last_pos != 0){
+		result.append(" ");
+	}
+
+	while (std::string::npos != pos || std::string::npos != last_pos) {
+		result.append(str.substr(last_pos, pos - last_pos));
+		last_pos = str.find_first_not_of(whitespace, pos);
+		if (last_pos > pos)
+			result.append(" ");
+		pos = str.find_first_of(whitespace, last_pos);
+	}
+
+	return result;
 }
 
 std::vector<std::string> utils::tokenize_nl(const std::string& str, std::string delimiters) {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -193,10 +193,10 @@ std::vector<std::string> utils::tokenize_spaced(const std::string& str, std::str
 
 std::string utils::consolidate_whitespace(const std::string& str, std::string whitespace) {
 	std::string result;
-	std::string::size_type last_pos = str.find_first_not_of(whitespace, 0);
+	std::string::size_type last_pos = str.find_first_not_of(whitespace);
 	std::string::size_type pos = str.find_first_of(whitespace, last_pos);
 
-	if(last_pos != 0){
+	if (last_pos != 0) {
 		result.append(" ");
 	}
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -196,7 +196,7 @@ std::string utils::consolidate_whitespace(const std::string& str, std::string wh
 	std::string::size_type last_pos = str.find_first_not_of(whitespace);
 	std::string::size_type pos = str.find_first_of(whitespace, last_pos);
 
-	if (last_pos != 0) {
+	if (last_pos != 0 && str != "") {
 		result.append(" ");
 	}
 

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -45,7 +45,7 @@ TEST_CASE("Tokenizers behave correctly", "[utils]") {
 		REQUIRE(tokens[0] == " ");
 		// second token is a
 		REQUIRE(tokens[1] == "a");
-		// third token is space
+		// third token is a tab followed by a space
 		REQUIRE(tokens[2] == "\t ");
 		// fourth token is b
 		REQUIRE(tokens[3] == "b");
@@ -123,7 +123,6 @@ TEST_CASE("utils::consolidate_whitespace bahaves correctly", "[utils]") {
 	std::string result = utils::consolidate_whitespace("    Lorem \t\tIpsum ");
 	REQUIRE(result == " Lorem Ipsum ");
 }
-
 
 TEST_CASE("String conversions behave correctly", "[utils]") {
 	SECTION("Conversion from wstring to string") {

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -46,7 +46,7 @@ TEST_CASE("Tokenizers behave correctly", "[utils]") {
 		// second token is a
 		REQUIRE(tokens[1] == "a");
 		// third token is space
-		REQUIRE(tokens[2] == " ");
+		REQUIRE(tokens[2] == "\t ");
 		// fourth token is b
 		REQUIRE(tokens[3] == "b");
 		// fifth token is space
@@ -118,6 +118,12 @@ TEST_CASE("Tokenizers behave correctly", "[utils]") {
 		}
 	}
 }
+
+TEST_CASE("utils::consolidate_whitespace bahaves correctly", "[utils]") {
+	std::string result = utils::consolidate_whitespace("    Lorem \t\tIpsum ");
+	REQUIRE(result == " Lorem Ipsum ");
+}
+
 
 TEST_CASE("String conversions behave correctly", "[utils]") {
 	SECTION("Conversion from wstring to string") {

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -119,9 +119,16 @@ TEST_CASE("Tokenizers behave correctly", "[utils]") {
 	}
 }
 
-TEST_CASE("utils::consolidate_whitespace bahaves correctly", "[utils]") {
-	std::string result = utils::consolidate_whitespace("    Lorem \t\tIpsum ");
-	REQUIRE(result == " Lorem Ipsum ");
+TEST_CASE("consolidate_whitespace replaces multiple consecutine"
+          "whitespace with a single space", "[utils]") {
+	REQUIRE(utils::consolidate_whitespace("LoremIpsum") == "LoremIpsum");
+	REQUIRE(utils::consolidate_whitespace("Lorem Ipsum") == "Lorem Ipsum");
+	REQUIRE(utils::consolidate_whitespace("    Lorem \t\tIpsum \t ") == " Lorem Ipsum ");
+	REQUIRE(utils::consolidate_whitespace("    Lorem \r\n\r\n\tIpsum") == " Lorem Ipsum");
+
+	REQUIRE(utils::consolidate_whitespace("") == " ");
+
+	REQUIRE(utils::consolidate_whitespace("  Lorem|||Ipsum||", "|") == "  Lorem Ipsum ");
 }
 
 TEST_CASE("String conversions behave correctly", "[utils]") {

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -126,7 +126,7 @@ TEST_CASE("consolidate_whitespace replaces multiple consecutine"
 	REQUIRE(utils::consolidate_whitespace("    Lorem \t\tIpsum \t ") == " Lorem Ipsum ");
 	REQUIRE(utils::consolidate_whitespace("    Lorem \r\n\r\n\tIpsum") == " Lorem Ipsum");
 
-	REQUIRE(utils::consolidate_whitespace("") == " ");
+	REQUIRE(utils::consolidate_whitespace("") == "");
 
 	REQUIRE(utils::consolidate_whitespace("  Lorem|||Ipsum||", "|") == "  Lorem Ipsum ");
 }


### PR DESCRIPTION
Whitespace consolidation was done in tokenize_spaced() which was used
from the wrap_lines function. To account for softwrappable lines, which
we don't want to consolidate the whitespace on, the behaviour of
tokenize_spaced what changed from consolidating whitespace to simply
tokenizing and leaving whitespace intact. Consolidation was moved to the
new consolidate_whitespace() function.