### PR TITLE
Clean up incorrect article flags

### DIFF
--- a/src/rss.cpp
+++ b/src/rss.cpp
@@ -302,10 +302,12 @@ void rss_item::set_flags(const std::string& ff) {
 void rss_item::sort_flags() {
 	std::sort(flags_.begin(), flags_.end());
 
-	for (auto it=flags_.begin(); flags_.size() > 0 && it!=flags_.end(); ++it) {
+	auto it=flags_.begin();
+	while (it!=flags_.end()) {
 		if (!isalpha(*it)) {
 			flags_.erase(it);
-			it = flags_.begin();
+		} else {
+			it += 1;
 		}
 	}
 

--- a/src/rss.cpp
+++ b/src/rss.cpp
@@ -312,7 +312,7 @@ void rss_item::sort_flags() {
 	for (unsigned int i=0; i<flags_.size(); ++i) {
 		if (i < (flags_.size()-1)) {
 			if (flags_[i] == flags_[i+1]) {
-				flags_.erase(i+1,i+1);
+				flags_.erase(i+1,1);
 				--i;
 			}
 		}

--- a/test/rss.cpp
+++ b/test/rss.cpp
@@ -249,4 +249,18 @@ TEST_CASE("set_rssurl checks if query feed has a valid query", "[rss]") {
 	}
 }
 
+TEST_CASE("rss_item::sort_flags() cleans up flags", "[rss]") {
+	configcontainer cfg;
+	cache rsscache(":memory:", &cfg);
+	rss_item item(&rsscache);
+
+	SECTION("Repeated letters do not erase other letters"){
+		std::string inputflags = "Abcdecf";
+		std::string result = "Abcdef";
+		item.set_flags(inputflags);
+		REQUIRE(result == item.flags());
+	}
+
+}
+
 }

--- a/test/rss.cpp
+++ b/test/rss.cpp
@@ -261,6 +261,11 @@ TEST_CASE("rss_item::sort_flags() cleans up flags", "[rss]") {
 		REQUIRE(result == item.flags());
 	}
 
+	SECTION("Non alpha characters in input flags are ignored"){
+		std::string inputflags = "Abcd";
+		item.set_flags(inputflags + "1234568790^\"#'é(£");
+		REQUIRE(inputflags == item.flags());
+	}
 }
 
 }


### PR DESCRIPTION
This modifies the rss_item::sort_flags function in rss.cpp in order to
correct two bugs in the way it cleans up the input flags. Changes are :
- sort_flags no longer fails to remove more than one following or identiqual
  non alphabetic characters.
- sort_flags no longer removes extra characters when a letter appears
  twice in the flag list.

Fixes #436 #437 #438

Link to build : https://travis-ci.org/akrennmair/newsbeuter/builds/179715117
