### PR TITLE
add support for the socks5h proxy type

### DIFF
--- a/doc/configcommands.dsv
+++ b/doc/configcommands.dsv
@@ -83,7 +83,7 @@ prepopulate-query-feeds|[yes/no]|no|If yes, then all query feeds are prepopulate
 ssl-verify|[yes/no]|yes|If no, skip SSL certificate validation.|ssl-verify no
 proxy-auth-method|<method>|any|Set proxy authentication method. Allowed values: any, basic, digest, digest_ie (only available with libcurl 7.19.3 and newer), gssnegotiate, ntlm, anysafe.|proxy-auth-method ntlm
 proxy-auth|<auth>|n/a|Set the proxy authentication string.|proxy-auth user:password
-proxy-type|<type>|http|Set proxy type. Allowed values: http, socks4, socks4a, socks5.|proxy-type socks5
+proxy-type|<type>|http|Set proxy type. Allowed values: http, socks4, socks4a, socks5, socks5h.|proxy-type socks5
 proxy|<server:port>|n/a|Set the proxy to use for downloading RSS feeds. (Don't forget to actually enable the proxy with `use-proxy yes`.)|proxy localhost:3128
 refresh-on-startup|[yes/no]|no|If yes, then all feeds will be reloaded when newsbeuter starts up. This is equivalent to the -r commandline option.|refresh-on-startup yes
 reload-only-visible-feeds|[yes/no]|no|If yes, then manually reloading all feeds will only reload the currently visible feeds, e.g. if a filter or a tag is set.|reload-only-visible-feeds yes

--- a/doc/example-config
+++ b/doc/example-config
@@ -983,7 +983,7 @@
 
 ####  proxy-type
 #
-# Set proxy type. Allowed values: http, socks4, socks4a, socks5.
+# Set proxy type. Allowed values: http, socks4, socks4a, socks5, socks5h.
 #
 # Syntax: <type>
 #

--- a/src/configcontainer.cpp
+++ b/src/configcontainer.cpp
@@ -111,7 +111,7 @@ configcontainer::configcontainer()
 		        "anysafe" })) },
 		{ "proxy-type",
 		    configdata("http", std::unordered_set<std::string>({
-		        "http", "socks4", "socks4a", "socks5" })) },
+		        "http", "socks4", "socks4a", "socks5", "socks5h" })) },
 		{ "refresh-on-startup", configdata("no", configdata_t::BOOL) },
 		{ "reload-only-visible-feeds", configdata("false", configdata_t::BOOL) },
 		{ "reload-threads", configdata("1", configdata_t::INT) },

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -975,6 +975,8 @@ curl_proxytype utils::get_proxy_type(const std::string& type) {
 		return CURLPROXY_SOCKS4;
 	if (type == "socks5")
 		return CURLPROXY_SOCKS5;
+	if (type == "socks5h")
+		return CURLPROXY_SOCKS5_HOSTNAME;
 #ifdef CURLPROXY_SOCKS4A
 	if (type == "socks4a")
 		return CURLPROXY_SOCKS4A;


### PR DESCRIPTION
The proxy type socks5h does the hostname resolution on the proxy instead
of the client (hence the name) and is therefore preferred with e.g Tor.

The socks5 type allows a client to do either with most performing the
DNS lookup locally and asking the socks5-proxy server to connect to a
specific IPv4/6. That can fail if the server has another network setup –
like no IPv6 – and in terms of Tor it means that DNS queries are leaked
and .onion addresses aren't working.