### PR TITLE
deduce article title from url if it is empty

### DIFF
--- a/src/rss_parser.cpp
+++ b/src/rss_parser.cpp
@@ -350,10 +350,15 @@ void rss_parser::fill_feed_items(std::shared_ptr<rss_feed> feed) {
 }
 
 void rss_parser::set_item_title(std::shared_ptr<rss_feed> feed, std::shared_ptr<rss_item> x, rsspp::item& item) {
+	std::string title = item.title;
+
+	if (item.title.empty()) {
+		title = utils::make_title(item.link);
+	}
+
 	if (is_html_type(item.title_type)) {
-		x->set_title(render_xhtml_title(item.title, feed->link()));
+		x->set_title(render_xhtml_title(title, feed->link()));
 	} else {
-		std::string title = item.title;
 		replace_newline_characters(title);
 		x->set_title(title);
 	}

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1069,6 +1069,11 @@ std::string utils::make_title(const std::string& const_url) {
 	if (title.at(0)>= 'a' && title.at(0)<= 'z') {
 		title[0] -= 'a' - 'A';
 	}
+	//strip .htm or .html from title
+	size_t pos = title.find(".html",0);
+	if (pos != std::string::npos) title.erase(pos,5);
+	pos = title.find(".htm",0);
+	if (pos != std::string::npos) title.erase(pos,4);
 	return title;
 }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -24,6 +24,7 @@
 #include <cstdarg>
 #include <cstdio>
 #include <algorithm>
+#include <regex>
 
 #include <curl/curl.h>
 
@@ -1062,6 +1063,9 @@ std::string utils::make_title(const std::string& const_url) {
 	std::string::size_type pos_of_qmrk = path.find_first_of('?');
 	//throw away the query part 'title-with-dashes'
 	std::string title = path.substr(0,pos_of_qmrk);
+	//Throw away common webpage suffixes: .html, .php, .aspx, .htm
+	std::regex rx("\\.html$|\\.htm$|\\.php$|\\.aspx$");
+	title = std::regex_replace(title,rx,"");
 	// 'title with dashes'
 	std::replace(title.begin(), title.end(), '-', ' ');
 	std::replace(title.begin(), title.end(), '_', ' ');
@@ -1069,11 +1073,6 @@ std::string utils::make_title(const std::string& const_url) {
 	if (title.at(0)>= 'a' && title.at(0)<= 'z') {
 		title[0] -= 'a' - 'A';
 	}
-	//strip .htm or .html from title
-	size_t pos = title.find(".html",0);
-	if (pos != std::string::npos) title.erase(pos,5);
-	pos = title.find(".htm",0);
-	if (pos != std::string::npos) title.erase(pos,4);
 	return title;
 }
 

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -353,6 +353,22 @@ TEST_CASE("utils::make_title extracts possible title from URL") {
 			input = "http://example.com/This_is-the_title";
 		}
 
+		SECTION("Eliminate .php extension") {
+			input = "http://example.com/This_is-the_title.php";
+		}
+
+		SECTION("Eliminate .html extension") {
+			input = "http://example.com/This_is-the_title.html";
+		}
+
+		SECTION("Eliminate .htm extension") {
+			input = "http://example.com/This_is-the_title.htm";
+		}
+
+		SECTION("Eliminate .aspx extension") {
+			input = "http://example.com/This_is-the_title.aspx";
+		}
+
 		REQUIRE(utils::make_title(input) == "This is the title");
 	}
 


### PR DESCRIPTION
Try to deduce title from url only if the parsed title is empty. This happens with some blogs which don't populate the title properly.

This patch uses the already existing function make_title, although it is improved to not include .html or .htm at the end of the title.
