### PR TITLE
Fix h5 and h6 html elements not being handled

### DIFF
--- a/include/htmlrenderer.h
+++ b/include/htmlrenderer.h
@@ -11,9 +11,9 @@ namespace newsbeuter {
 
 enum class link_type { HREF, IMG, EMBED };
 enum class htmltag {
-	A = 1, EMBED, BR, PRE, ITUNESHACK, IMG, BLOCKQUOTE, H1, H2, H3, H4, P, OL,
-	UL, LI, DT, DD, DL, SUP, SUB, HR, STRONG, UNDERLINE, QUOTATION, SCRIPT,
-	STYLE, TABLE, TH, TR, TD
+	A = 1, EMBED, BR, PRE, ITUNESHACK, IMG, BLOCKQUOTE, H1, H2, H3, H4, H5, H6,
+	P, OL, UL, LI, DT, DD, DL, SUP, SUB, HR, STRONG, UNDERLINE, QUOTATION,
+	SCRIPT, STYLE, TABLE, TH, TR, TD
 };
 
 typedef std::pair<std::string,link_type> linkpair;

--- a/src/htmlrenderer.cpp
+++ b/src/htmlrenderer.cpp
@@ -28,6 +28,8 @@ htmlrenderer::htmlrenderer(bool raw) : raw_(raw) {
 	tags["h2"] = htmltag::H2;
 	tags["h3"] = htmltag::H3;
 	tags["h4"] = htmltag::H4;
+	tags["h5"] = htmltag::H5;
+	tags["h6"] = htmltag::H6;
 	tags["ol"] = htmltag::OL;
 	tags["ul"] = htmltag::UL;
 	tags["li"] = htmltag::LI;
@@ -226,6 +228,8 @@ void htmlrenderer::render(
 			case htmltag::H2:
 			case htmltag::H3:
 			case htmltag::H4:
+			case htmltag::H5:
+			case htmltag::H6:
 			case htmltag::P:
 				{
 				add_nonempty_line(curline, tables, lines);
@@ -451,6 +455,8 @@ void htmlrenderer::render(
 			case htmltag::H2:
 			case htmltag::H3:
 			case htmltag::H4:
+			case htmltag::H5:
+			case htmltag::H6:
 			case htmltag::P:
 				add_nonempty_line(curline, tables, lines);
 				prepare_new_line(curline,  tables.size() ? 0 : indent_level);


### PR DESCRIPTION
HTML has up to 6 header elements([source](http://www.w3schools.com/html/html_headings.asp)), newsbeuter only supported up to h4.