### PR TITLE
Evaluate the commit hash once when compiling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ CXX?=c++
 DEFINES=-DLOCALEDIR=\"$(localedir)\"
 
 ifneq ($(wildcard .git/.),)
-GIT_HASH=$(shell git describe --abbrev=4 --dirty --always --tags)
+GIT_HASH:=$(shell git describe --abbrev=4 --dirty --always --tags)
 DEFINES+=-DGIT_HASH=\"$(GIT_HASH)\"
 endif
 


### PR DESCRIPTION
A makefile assignment with `=` will be expanded every time it is
referenced. This meant that the git command would be run every time it
was referenced in a compiler call.

Instead, it is better to use `:=` which expands the value once when it is
assigned. This prevents multiple calls to git saving a few precious CPU
cycles.