### PR TITLE
dont abort on empty title in utils::make_title

### DIFF
--- a/src/tagsouppullparser.cpp
+++ b/src/tagsouppullparser.cpp
@@ -68,12 +68,12 @@ tagsouppullparser::event tagsouppullparser::next() {
 		skip_whitespace();
 		if (inputstream->eof()) {
 			current_event = event::END_DOCUMENT;
-			break;
-		}
-		if (c != '<') {
+		} else if (c != '<') {
 			handle_text();
-			break;
+		} else {
+			handle_tag();
 		}
+		break;
 	case event::TEXT:
 		handle_tag();
 		break;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1066,6 +1066,9 @@ std::string utils::make_title(const std::string& const_url) {
 	//Throw away common webpage suffixes: .html, .php, .aspx, .htm
 	std::regex rx("\\.html$|\\.htm$|\\.php$|\\.aspx$");
 	title = std::regex_replace(title,rx,"");
+	// if there is nothing left, just give up
+	if (title.empty())
+		return title;
 	// 'title with dashes'
 	std::replace(title.begin(), title.end(), '-', ' ');
 	std::replace(title.begin(), title.end(), '_', ' ');

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1077,9 +1077,10 @@ std::string utils::make_title(const std::string& const_url) {
 		title[0] -= 'a' - 'A';
 	}
 	// Un-escape any percent-encoding, e.g. "It%27s%202017%21" -> "It's 2017!"
-	char* result = xmlURIUnescapeString(title.c_str(), 0, nullptr);
+	auto const result = xmlURIUnescapeString(title.c_str(), 0, nullptr);
 	if (result) {
 		title = result;
+		xmlFree(result);
 	}
 	return title;
 }

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -417,6 +417,11 @@ TEST_CASE("utils::make_title extracts possible title from URL") {
 		auto input = "https://example.com/It%27s%202017%21";
 		REQUIRE(utils::make_title(input) == "It's 2017!");
 	}
+
+	SECTION("Deal with an empty last component") {
+		auto input = "https://example.com/?format=rss";
+		REQUIRE(utils::make_title(input) == "");
+	}
 }
 
 TEST_CASE("remove_soft_hyphens remove all U+00AD characters from a string",


### PR DESCRIPTION
Hi,

I have a feed (https://www.heute.de/?view=rss) which includes "sometimes" completely broken items, which due to newsbeuter trying to generate a title for those items results in an abort by an unhandled exception. The commit in the "middle" is fixing the abort in the util function, but perhaps on a more global view newsbeuter maybe shouldn't act on strange items.

Anyway, I stumbled over two tiny other things in the process and have that included here as well as I was too lazy to make independent pullrequest for it, but if you prefer I will try to be less lazy. ;)

Best regards

David