### PR TITLE
Fix broken documentation introduced by fix for #334

### DIFF
--- a/doc/chapter-firststeps.txt
+++ b/doc/chapter-firststeps.txt
@@ -84,7 +84,7 @@ also contain comments, which start with the '#' character and go as far as the
 end of line. If you need to enter a configuration argument that contains
 spaces, use quotes (") around the whole argument. It's even possible to
 integrate the output of external commands into the configuration. The text
-between two backticks ("`") is evaluated as shell command, and its output is
+between two backticks ("\`") is evaluated as shell command, and its output is
 put on its place instead. This works like backtick evaluation in
 Bourne-compatible shells and allows users to use external information from the
 system within the configuration. Backticks can be escaped with a backslash


### PR DESCRIPTION
AsciiDoc only (seems to) interpret backticks as "representing code" if they are balanced. The previous documentation only contained a single backtick. By extending the documentation and adding another backtick everything in between was interpreted as code.

Escaping the first backtick seems to fix this. Interestingly you only have to and only can escape the first backtick. Which could lead to the same behavior in the long run if other backticks are added.

Fun fact: #334 linked to another issue fittingly named "Consider checking if backticks in config are balanced" :smile: 