### PR TITLE
Fixes #367 (alignment error in item list)

### DIFF
--- a/src/itemlist_formaction.cpp
+++ b/src/itemlist_formaction.cpp
@@ -750,6 +750,8 @@ std::string itemlist_formaction::item2formatted_line(
 
 	fmt.register_fmt('L', item.first->length());
 
+  tmp_itemlist_format = fmt.do_format(tmp_itemlist_format,width);
+
 	if (rxman) {
 		int id;
 		if ((id = rxman->article_matches(item.first.get())) != -1) {
@@ -763,7 +765,7 @@ std::string itemlist_formaction::item2formatted_line(
 			"<unread>%s</>", tmp_itemlist_format);
 	}
 
-	return fmt.do_format(tmp_itemlist_format, width);
+	return tmp_itemlist_format;
 }
 
 void itemlist_formaction::init() {


### PR DESCRIPTION
The problem is that, internally, newsbeuter encloses the unread items with `<unread>…</>` tags (presumably for highlighting/colouring – they disappear at a later stage, though I do not know when) before calling the do_format function, which therefore works with a string of the wrong length and gets the alignment wrong. 

My fix is to call do_format first, then (if needed) enclose the string with tags.

It works for me, but I don't understand the context too well, so please check & test.