### PR TITLE
ssl-verify → ssl-verifypeer; add ssl-verifyhost

### DIFF
--- a/doc/configcommands.dsv
+++ b/doc/configcommands.dsv
@@ -72,7 +72,6 @@ ocnews-password|<password>|""|Configures the password to use with the ownCloud i
 ocnews-passwordfile|<path-to-file>|""|A more secure alternative to the above, by storing your password elsewhere in your system.|ocnews-passwordfile "path-to-file"
 ocnews-passwordeval|<command>|""|Another secure alternative, is providing your password from an external command that is evaluated during login. This can be used to read your password from a gpg encrypted file or your system keyring.|ocnews-passwordeval "command some-parameter"
 ocnews-url|<url>|""|Configures the URL where the ownCloud instance resides.|ocnews-url "https://localhost/owncloud"
-ocnews-verifyhost|[yes/no]|yes|If this is set to no, the connection the ownCloud instance will not verify the certificate's name against the host's name.|ocnews-verifyhost no
 oldreader-flag-share|<flag>|""|If this is set and The Old Reader support is used, then all articles that are flagged with the specified flag are being "shared" in The Old Reader so that people that follow you can see it.|oldreader-flag-share "a"
 oldreader-flag-star|<flag>|""|If this is set and The Old Reader support is used, then all articles that are flagged with the specified flag are being "starred" in The Old Reader and appear in the list of "Starred items".|oldreader-flag-star "b"
 oldreader-login|<login>|""|This variable sets your The Old Reader login for The Older Reader support.|oldreader-login "your-login"
@@ -86,7 +85,8 @@ opml-url|<url> ...|""|If the OPML online subscription mode is enabled, then the 
 pager|[<path>/internal]|internal|If set to "internal", then the internal pager will be used. Otherwise, the article to be displayed will be rendered to be a temporary file and then displayed with the configured pager. If the pager path is set to an empty string, the content of the "PAGER" environment variable will be used. If the pager path contains a placeholder "%f", it will be replaced with the temporary filename.|less %f
 podcast-auto-enqueue|[yes/no]|no|If yes, then all podcast URLs that are found in articles are added to the podcast download queue. See the respective section in the documentation for more information on podcast support in newsbeuter.|podcast-auto-enqueue yes
 prepopulate-query-feeds|[yes/no]|no|If yes, then all query feeds are prepopulated with articles on startup.|prepopulate-query-feeds yes
-ssl-verify|[yes/no]|yes|If no, skip SSL certificate validation.|ssl-verify no
+ssl-verifyhost|[yes/no]|yes|If no, skip verification of the certificate's name against host.|ssl-verifyhost no
+ssl-verifypeer|[yes/no]|yes|If no, skip verification of the peer's SSL certificate.|ssl-verifypeer no
 proxy-auth-method|<method>|any|Set proxy authentication method. Allowed values: any, basic, digest, digest_ie (only available with libcurl 7.19.3 and newer), gssnegotiate, ntlm, anysafe.|proxy-auth-method ntlm
 proxy-auth|<auth>|n/a|Set the proxy authentication string.|proxy-auth user:password
 proxy-type|<type>|http|Set proxy type. Allowed values: http, socks4, socks4a, socks5, socks5h.|proxy-type socks5

--- a/doc/example-config
+++ b/doc/example-config
@@ -854,17 +854,6 @@
 #
 # ocnews-url "https://localhost/owncloud"
 
-####  ocnews-verifyhost
-#
-# If this is set to no, the connection the ownCloud instance will not verify
-# the certificate's name against the host's name.
-#
-# Syntax: [yes/no]
-#
-# Default value: yes
-#
-# ocnews-verifyhost no
-
 ####  oldreader-flag-share
 #
 # If this is set and The Old Reader support is used, then all articles that are
@@ -1018,15 +1007,25 @@
 #
 # prepopulate-query-feeds yes
 
-####  ssl-verify
+####  ssl-verifyhost
 #
-# If no, skip SSL certificate validation.
+# If no, skip verification of the certificate's name against host.
 #
 # Syntax: [yes/no]
 #
 # Default value: yes
 #
-# ssl-verify no
+# ssl-verifyhost no
+
+####  ssl-verifypeer
+#
+# If no, skip verification of the peer's SSL certificate.
+#
+# Syntax: [yes/no]
+#
+# Default value: yes
+#
+# ssl-verifypeer no
 
 ####  proxy-auth-method
 #

--- a/include/ocnews_api.h
+++ b/include/ocnews_api.h
@@ -29,7 +29,6 @@ class ocnews_api : public remote_api {
 		std::string md5(const std::string& str);
 		std::string auth;
 		std::string server;
-		bool verifyhost;
 		feedmap known_feeds;
 };
 

--- a/src/configcontainer.cpp
+++ b/src/configcontainer.cpp
@@ -106,7 +106,8 @@ configcontainer::configcontainer()
 		{ "player", configdata("", configdata_t::PATH) },
 		{ "podcast-auto-enqueue", configdata("no", configdata_t::BOOL) },
 		{ "prepopulate-query-feeds", configdata("false", configdata_t::BOOL) },
-		{ "ssl-verify", configdata("true", configdata_t::BOOL) },
+		{ "ssl-verifyhost", configdata("true", configdata_t::BOOL) },
+		{ "ssl-verifypeer", configdata("true", configdata_t::BOOL) },
 		{ "proxy", configdata("", configdata_t::STR) },
 		{ "proxy-auth", configdata("", configdata_t::STR) },
 		{ "proxy-auth-method",
@@ -147,8 +148,6 @@ configcontainer::configcontainer()
 		{ "ocnews-passwordeval", configdata("", configdata_t::STR) },
 		{ "ocnews-flag-star", configdata("", configdata_t::STR) },
 		{ "ocnews-url", configdata("", configdata_t::STR) },
-		{ "ocnews-verifyhost",
-		    configdata("yes", configdata_t::BOOL) },
 		{ "urls-source",
 		    configdata("local", std::unordered_set<std::string>({
 		        "local", "opml", "oldreader", "ttrss", "newsblur",

--- a/src/ocnews_api.cpp
+++ b/src/ocnews_api.cpp
@@ -19,7 +19,6 @@ typedef std::unique_ptr<CURL, decltype(*curl_easy_cleanup)> curl_uptr;
 
 ocnews_api::ocnews_api(configcontainer* c) : remote_api(c) {
 	server = cfg->get_configvalue("ocnews-url");
-	verifyhost = cfg->get_configvalue_as_bool("ocnews-verifyhost");
 
 	if (server.empty())
 		LOG(level::CRITICAL, "ocnews_api::ocnews_api: No owncloud server set");
@@ -258,9 +257,6 @@ bool ocnews_api::query(const std::string& query, json_object** result, const std
 	std::string buff;
 	curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, *write_fn);
 	curl_easy_setopt(handle, CURLOPT_WRITEDATA, &buff);
-
-	if (!verifyhost)
-		curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, 0);
 
 	if (!post.empty()) {
 		curl_easy_setopt(handle, CURLOPT_POST, 1);

--- a/src/rss_parser.cpp
+++ b/src/rss_parser.cpp
@@ -168,7 +168,7 @@ void rss_parser::download_http(const std::string& uri) {
 		try {
 			std::string useragent = utils::get_useragent(cfgcont);
 			LOG(level::DEBUG, "rss_parser::download_http: user-agent = %s", useragent);
-			rsspp::parser p(cfgcont->get_configvalue_as_int("download-timeout"), useragent.c_str(), proxy.c_str(), proxy_auth.c_str(), utils::get_proxy_type(proxy_type), cfgcont->get_configvalue_as_bool("ssl-verify"));
+			rsspp::parser p(cfgcont->get_configvalue_as_int("download-timeout"), useragent.c_str(), proxy.c_str(), proxy_auth.c_str(), utils::get_proxy_type(proxy_type), cfgcont->get_configvalue_as_bool("ssl-verifypeer"));
 			time_t lm = 0;
 			std::string etag;
 			if (!ign || !ign->matches_lastmodified(uri)) {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -904,7 +904,8 @@ void utils::set_common_curl_options(CURL * handle, configcontainer * cfg) {
 		cookie_cache = cfg->get_configvalue("cookie-cache");
 	}
 
-	curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, cfg->get_configvalue_as_bool("ssl-verify"));
+	curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, cfg->get_configvalue_as_bool("ssl-verifyhost") ? 2 : 0);
+	curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, cfg->get_configvalue_as_bool("ssl-verifypeer"));
 	curl_easy_setopt(handle, CURLOPT_NOSIGNAL, 1);
 	curl_easy_setopt(handle, CURLOPT_ENCODING, "gzip, deflate");
 	curl_easy_setopt(handle, CURLOPT_TIMEOUT, dl_timeout);


### PR DESCRIPTION
Looks we should allow curl access such https ownCloud sites just like
other clients did if user set ocnews-verifypeer to no.

I notice the #248 said will dispatch such certificate verification problems, too. Anyway, for some users, the feature is necessary ;)

Thanks.
