### PR TITLE
Unset macros to prevent 'redefined' errors during build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,11 @@ CPPCHECK_JOBS?=5
 CXX?=c++
 
 # compiler and linker flags
-DEFINES=-DLOCALEDIR=\"$(localedir)\"
+DEFINES=-ULOCALEDIR -DLOCALEDIR=\"$(localedir)\"
 
 ifneq ($(wildcard .git/.),)
 GIT_HASH:=$(shell git describe --abbrev=4 --dirty --always --tags)
-DEFINES+=-DGIT_HASH=\"$(GIT_HASH)\"
+DEFINES+=-UGIT_HASH -DGIT_HASH=\"$(GIT_HASH)\"
 endif
 
 WARNFLAGS=-Werror -Wall -Wextra -Wunreachable-code


### PR DESCRIPTION
In preparation to a (hopefully soon :) ) new release of newsbeuter, I tried to build Debian/Ubuntu binaries. Currently the build fails with
```
<command-line>:0:0: error: "LOCALEDIR" redefined [-Werror]
<command-line>:0:0: note: this is the location of the previous definition
cc1plus: all warnings being treated as errors
Makefile:112: recipe for target 'test/cache.o' failed
make[1]: *** [test/cache.o] Error 1
```
Unsetting the build macros before (re)setting them prevents this.

Tested on my private Launchpad PPA: https://launchpad.net/~x4121/+archive/ubuntu/ppa/+build/12464800 (which should behave similar/identical to the Debian build server that the release would be built on)