### PR TITLE
Correct dc:creator in rss_10_parser.cpp

### DIFF
--- a/rss/rss_10_parser.cpp
+++ b/rss/rss_10_parser.cpp
@@ -47,7 +47,7 @@ void rss_10_parser::parse_feed(feed& f, xmlNode * rootNode) {
 					it.content_encoded = get_content(itnode);
 				} else if (node_is(itnode, "summary", ITUNES_URI)) {
 					it.itunes_summary = get_content(itnode);
-				} else if (node_is(itnode, "creator", DC_URI)) {
+				} else if (node_is(itnode, "dc:creator", DC_URI)) {
 					it.author = get_content(itnode);
 				}
 			}


### PR DESCRIPTION
Change item field `creator` to `dc:creator`. This corresponds to the [Dublin Core](http://web.resource.org/rss/1.0/modules/dc/) specification as well as real-world usage. See issue #143.