### PR TITLE
Removes redraw of screen when 'reload-all' completes

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -891,8 +891,6 @@ void controller::reload_all(bool unattended) {
 	for (auto feed : feeds) {
 		v->prepare_query_feed(feed);
 	}
-	v->force_redraw();
-
 	sort_feeds();
 	update_feedlist();
 


### PR DESCRIPTION
This fixes a bug where if
1. A 'reload-all' was executed, and immediately subsequently
2. The user began reading an article as the reload completed in the
background, this would result in
3. The article on screen would reload when the reload
completed, resetting the any scrolling and perhaps changing the title of
the article to garbage

Fixes #534 