### PR TITLE
TTRSS-API: only set auth_info for "Single" ttrss-mode

### DIFF
--- a/doc/newsbeuter.txt
+++ b/doc/newsbeuter.txt
@@ -669,6 +669,14 @@ authentication is done against Tiny Tiny RSS itself.
 
 	ttrss-mode "single"		# "multi" is default
 
+If Tiny Tiny RSS is configured in multi-user mode and still deployed behind 
+an additional HTTP-BasicAuth, the required username and password (which may 
+deviate from ttrss-login and ttrss-password) can be specified in the user-part 
+of the url like this:
+
+    ttrss-url "http://htuser:htpasswd@example.com/ttrss/"
+
+
 With these settings, newsbeuter should be able to connect to Tiny Tiny RSS and 
 download your subscribed feeds. Articles or even complete feeds that you marked 
 as read are synchronized directly to Tiny Tiny RSS.

--- a/src/ttrss_api.cpp
+++ b/src/ttrss_api.cpp
@@ -12,7 +12,11 @@ namespace newsbeuter {
 
 ttrss_api::ttrss_api(configcontainer * c) : remote_api(c) {
 	single = (cfg->get_configvalue("ttrss-mode") == "single");
-	auth_info = strprintf::fmt("%s:%s", cfg->get_configvalue("ttrss-login"), cfg->get_configvalue("ttrss-password"));
+	if (single) {
+		auth_info = strprintf::fmt("%s:%s", cfg->get_configvalue("ttrss-login"), cfg->get_configvalue("ttrss-password"));
+	} else {
+		auth_info = "";
+	}
 	sid = "";
 }
 
@@ -42,7 +46,11 @@ std::string ttrss_api::retrieve_sid() {
 
 	args["user"] = single ? "admin" : cred.user.c_str();
 	args["password"] = cred.pass.c_str();
-	auth_info = strprintf::fmt("%s:%s", cred.user, cred.pass);
+	if (single) {
+		auth_info = strprintf::fmt("%s:%s", cred.user, cred.pass);
+	} else {
+		auth_info = "";
+	}
 	json_object * content = run_op("login", args);
 
 	if (content == nullptr)


### PR DESCRIPTION
Currently, newsbeuter sets the HTTP-Auth parameter for all requests that
target the TTRSS-api from the "ttrss-login" and "ttrss-password" config
file options. This explicitly provided auth_info takes precedence over
optionally provided user-information in libcurl.

Therefore the following config settings

```
    urls-source    "ttrss"
    ttrss-url      "https://htuser:htpasswd@ttrssinstance.example.org"

    ttrss-login    "ttrssuser"
    ttrss-password "ttrsspasswd"
```

will try to query `trssinstance.example.org` with auth_info
`ttrssuser:ttrsspasswd` and consequently fail, while libcurl as such
would happily accept the auth info from `ttrss-url` when no explicit
auth-info was provided.

This commit rectifies this and consequently allows newsbeuter to use
multiuser-TTRSS instances which are hosted behind http-basic auth.

This pullrequest is intended to be minimal and I would be happy to make adaptions as necessary, I just wanted to get the discussion going.
One might prefere to add dedicated auth-info fields to the configfile (e.g. `ttrss-httpauth-user` and `ttrss-httpauth-password`) for this settings, so I personally believe them to be unnecessary.

Thank you for newsbeuter as such and for considering this pull-request,
Simon