### PR TITLE
intercept browser's failure (issue #448)

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -67,7 +67,7 @@ class view {
 		std::string select_tag();
 		std::string select_filter(const std::vector<filter_name_expr_pair>& filters);
 
-		void open_in_browser(const std::string& url);
+		bool open_in_browser(const std::string& url);
 		void open_in_pager(const std::string& filename);
 
 		std::string get_filename_suggestion(const std::string& s);

--- a/src/itemlist_formaction.cpp
+++ b/src/itemlist_formaction.cpp
@@ -87,7 +87,7 @@ void itemlist_formaction::process_operation(operation op, bool automatic, std::v
 
 				bool browser_success = v->open_in_browser(visible_items[itempos].first->link());
 				if (!browser_success) {
-					v->show_error(_("browser failed to open the link"));
+					v->show_error(_("Browser failed to open the link!"));
 					break;
 				}
 

--- a/src/itemlist_formaction.cpp
+++ b/src/itemlist_formaction.cpp
@@ -86,8 +86,10 @@ void itemlist_formaction::process_operation(operation op, bool automatic, std::v
 			if (itempos < visible_items.size()) {
 
 				bool browser_success = v->open_in_browser(visible_items[itempos].first->link());
-				if (!browser_success)
+				if (!browser_success) {
+					v->show_error(_("browser failed to open the link"));
 					break;
+				}
 
 				visible_items[itempos].first->set_unread(false);
 				v->get_ctrl()->mark_article_read(visible_items[itempos].first->guid(), true);

--- a/src/itemlist_formaction.cpp
+++ b/src/itemlist_formaction.cpp
@@ -84,11 +84,19 @@ void itemlist_formaction::process_operation(operation op, bool automatic, std::v
 		LOG(level::INFO, "itemlist_formaction: opening item at pos `%s'", itemposname);
 		if (itemposname.length() > 0 && visible_items.size() != 0) {
 			if (itempos < visible_items.size()) {
-				visible_items[itempos].first->set_unread(false);
-				v->get_ctrl()->mark_article_read(visible_items[itempos].first->guid(), true);
-				v->open_in_browser(visible_items[itempos].first->link());
+				// store if open_in_browser() succeded
+				bool browser_success = v->open_in_browser(visible_items[itempos].first->link());
+				// do only mark as unread if open_in_browser() succeded
+				if (browser_success) {
+					visible_items[itempos].first->set_unread(false);
+					v->get_ctrl()->mark_article_read(visible_items[itempos].first->guid(), true);
+				}
 				if (!v->get_cfg()->get_configvalue_as_bool("openbrowser-and-mark-jumps-to-next-unread")) {
-					if (itempos < visible_items.size()-1) {
+					/* do only scroll if 
+					 *  - XXX TODO explain first condition
+					 *  - open_in_browser() succeded
+					 */
+					if (itempos < visible_items.size()-1 && browser_success) {
 						f->set("itempos", strprintf::fmt("%u", itempos + 1));
 					}
 				} else {

--- a/src/itemlist_formaction.cpp
+++ b/src/itemlist_formaction.cpp
@@ -84,19 +84,16 @@ void itemlist_formaction::process_operation(operation op, bool automatic, std::v
 		LOG(level::INFO, "itemlist_formaction: opening item at pos `%s'", itemposname);
 		if (itemposname.length() > 0 && visible_items.size() != 0) {
 			if (itempos < visible_items.size()) {
-				// store if open_in_browser() succeded
+
 				bool browser_success = v->open_in_browser(visible_items[itempos].first->link());
-				// do only mark as unread if open_in_browser() succeded
-				if (browser_success) {
-					visible_items[itempos].first->set_unread(false);
-					v->get_ctrl()->mark_article_read(visible_items[itempos].first->guid(), true);
-				}
+				if (!browser_success)
+					break;
+
+				visible_items[itempos].first->set_unread(false);
+				v->get_ctrl()->mark_article_read(visible_items[itempos].first->guid(), true);
+
 				if (!v->get_cfg()->get_configvalue_as_bool("openbrowser-and-mark-jumps-to-next-unread")) {
-					/* do only scroll if 
-					 *  - XXX TODO explain first condition
-					 *  - open_in_browser() succeded
-					 */
-					if (itempos < visible_items.size()-1 && browser_success) {
+					if (itempos < visible_items.size()-1) {
 						f->set("itempos", strprintf::fmt("%u", itempos + 1));
 					}
 				} else {

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -359,15 +359,13 @@ bool view::open_in_browser(const std::string& url) {
 		cmdline.append("'");
 	}
 	stfl::reset();
-	// store the shell return value
-	int status_browser = utils::run_interactively(cmdline, "view::open_in_browser");
-	// the browser returned a value unequal to zero
-	if (status_browser) {
-		std::clog << strprintf::fmt(_("Starting the browser failed with error code %d"), status_browser) << std::endl;
+	int browser_exit_code = utils::run_interactively(cmdline, "view::open_in_browser");
+	if (browser_exit_code == 0) {
+		LOG(level::DEBUG, "Starting the browser failed with error code %d - command was %s\n", browser_exit_code, cmdline);
 	}
 	pop_current_formaction();
 
-	if (status_browser) return false;
+	if (browser_exit_code) return false;
 	else return true;
 }
 

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -360,13 +360,13 @@ bool view::open_in_browser(const std::string& url) {
 	}
 	stfl::reset();
 	int browser_exit_code = utils::run_interactively(cmdline, "view::open_in_browser");
-	if (browser_exit_code == 0) {
-		LOG(level::DEBUG, "Starting the browser failed with error code %d - command was %s\n", browser_exit_code, cmdline);
+	if (browser_exit_code != 0) {
+		LOG(level::DEBUG, "utils::run_interactively: "
+			"Starting the browser failed with error code %d - command was %s", browser_exit_code, cmdline);
 	}
 	pop_current_formaction();
 
-	if (browser_exit_code) return false;
-	else return true;
+	return browser_exit_code == 0;
 }
 
 void view::update_visible_feeds(std::vector<std::shared_ptr<rss_feed>> feeds) {

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -336,7 +336,7 @@ void view::open_in_pager(const std::string& filename) {
 	pop_current_formaction();
 }
 
-void view::open_in_browser(const std::string& url) {
+bool view::open_in_browser(const std::string& url) {
 	formaction_stack.push_back(std::shared_ptr<formaction>());
 	current_formaction = formaction_stack_size() - 1;
 	std::string cmdline;
@@ -359,8 +359,16 @@ void view::open_in_browser(const std::string& url) {
 		cmdline.append("'");
 	}
 	stfl::reset();
-	utils::run_interactively(cmdline, "view::open_in_browser");
+	// store the shell return value
+	int status_browser = utils::run_interactively(cmdline, "view::open_in_browser");
+	// the browser returned a value unequal to zero
+	if (status_browser) {
+		std::clog << strprintf::fmt(_("Starting the browser failed with error code %d"), status_browser) << std::endl;
+	}
 	pop_current_formaction();
+
+	if (status_browser) return false;
+	else return true;
 }
 
 void view::update_visible_feeds(std::vector<std::shared_ptr<rss_feed>> feeds) {


### PR DESCRIPTION
When opening a link the browser may return a value unequal to zero.
This gets recognized and then printed to stderr.

If this happens during the "open-in-browser-and-mark-read"-operation neither
the article in question is marked as read nor it is scrolled down.

Unfortunately I had to change the method declaration of open_in_browser from void
to bool in order to transmit one bit of information to the outside of that
particular function. Although this should not be an issue as this is
syntactically allowed similar a line of code only persisting of a literal.