### PR TITLE
intercept browser's/pager's failure (issue #449)

### DIFF
--- a/include/pb_controller.h
+++ b/include/pb_controller.h
@@ -47,7 +47,7 @@ class pb_controller {
 
 		double get_total_kbps();
 
-		void play_file(const std::string& str);
+		bool play_file(const std::string& str) __attribute__((warn_unused_result));
 
 		inline newsbeuter::configcontainer * get_cfgcont() {
 			return cfg;

--- a/include/pb_view.h
+++ b/include/pb_view.h
@@ -23,6 +23,9 @@ class pb_view {
 			set_bindings();
 		}
 
+		void show_error (const std::string& msg) {
+			this->dllist_form.set("msg", msg);
+		}
 	private:
 
 		friend class newsbeuter::colormanager;
@@ -40,7 +43,6 @@ class pb_view {
 		std::string prepare_keymaphint(keymap_hint_entry * hints);
 		pb_controller * ctrl;
 		newsbeuter::stfl::form dllist_form;
-		friend class pb_controller; // to use newsbeuter::stfl::form::set()
 
 		newsbeuter::stfl::form help_form;
 		newsbeuter::keymap * keys;

--- a/include/pb_view.h
+++ b/include/pb_view.h
@@ -40,6 +40,8 @@ class pb_view {
 		std::string prepare_keymaphint(keymap_hint_entry * hints);
 		pb_controller * ctrl;
 		newsbeuter::stfl::form dllist_form;
+		friend class pb_controller; // to use newsbeuter::stfl::form::set()
+
 		newsbeuter::stfl::form help_form;
 		newsbeuter::keymap * keys;
 };

--- a/include/utils.h
+++ b/include/utils.h
@@ -135,7 +135,8 @@ class utils {
 		static std::string make_title(const std::string& url);
 
 		static int run_interactively(
-				const std::string& command, const std::string& caller);
+				const std::string& command, const std::string& caller)
+				__attribute__ ((warn_unused_result));
 
 		static std::string getcwd();
 

--- a/include/view.h
+++ b/include/view.h
@@ -67,8 +67,8 @@ class view {
 		std::string select_tag();
 		std::string select_filter(const std::vector<filter_name_expr_pair>& filters);
 
-		bool open_in_browser(const std::string& url);
-		bool open_in_pager(const std::string& filename);
+		bool open_in_browser(const std::string& url) __attribute__ ((warn_unused_result));;
+		bool open_in_pager(const std::string& filename) __attribute__ ((warn_unused_result));
 
 		std::string get_filename_suggestion(const std::string& s);
 

--- a/include/view.h
+++ b/include/view.h
@@ -68,7 +68,7 @@ class view {
 		std::string select_filter(const std::vector<filter_name_expr_pair>& filters);
 
 		bool open_in_browser(const std::string& url);
-		void open_in_pager(const std::string& filename);
+		bool open_in_pager(const std::string& filename);
 
 		std::string get_filename_suggestion(const std::string& s);
 

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -1317,17 +1317,16 @@ void controller::edit_urls_file() {
 	v->push_empty_formaction();
 	stfl::reset();
 
-	int editor_exit_code = utils::run_interactively(cmdline, "controller::edit_urls_file");
-	if (editor_exit_code != 0) {
-		LOG(level::DEBUG, "utils::run_interactively: "
-			"The editor failed with error code %d - command was %s", editor_exit_code, cmdline);
-	}
+	/* We should not check this particular exit code.
+	 * Editors usually fail when closing+saving (and stay open).
+	 * (tested with vim, nano, gedit, geany)
+	 * (texmaker 5.0.1 and notepadqq 1.0.1 close without neither showing an
+	 * error nor saving but despite return 0)
+	 */
+	int unused __attribute__((unused));
+	unused = utils::run_interactively(cmdline, "controller::edit_urls_file");
 
 	v->pop_current_formaction();
-
-	if (editor_exit_code != 0) {
-		v->show_error(_("Editor failed to open url file!"));
-	}
 
 	reload_urls_file();
 }
@@ -1364,7 +1363,10 @@ std::string controller::bookmark(
 		if (is_interactive) {
 			v->push_empty_formaction();
 			stfl::reset();
-			utils::run_interactively(cmdline, "controller::bookmark");
+			int bookmark_cmd_exit_code = utils::run_interactively(cmdline, "controller::bookmark");
+			if (bookmark_cmd_exit_code != 0) {
+				return "The bookmark command failed!";
+			}
 			v->pop_current_formaction();
 			return "";
 		} else {

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -1317,11 +1317,12 @@ void controller::edit_urls_file() {
 	v->push_empty_formaction();
 	stfl::reset();
 
-	/* We should not check this particular exit code.
-	 * Editors usually fail when closing+saving (and stay open).
-	 * (tested with vim, nano, gedit, geany)
-	 * (texmaker 5.0.1 and notepadqq 1.0.1 close without neither showing an
-	 * error nor saving but despite return 0)
+	 /* Most editors check for unsaved changes when attempting to exit and
+	 * prompt to either save or discard them. If save was choosen without
+	 * having write permissions a properly codd will fail and stay open
+	 * (like vim, nano, gedit, geany). However other editors (texmaker
+	 * 5.0.1 and notepadqq 1.0.1) close but despite return 0.
+	 * So we should not check this particular exit code.
 	 */
 	int unused __attribute__((unused));
 	unused = utils::run_interactively(cmdline, "controller::edit_urls_file");

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -1319,10 +1319,10 @@ void controller::edit_urls_file() {
 
 	 /* Most editors check for unsaved changes when attempting to exit and
 	 * prompt to either save or discard them. If save was choosen without
-	 * having write permissions a properly codd will fail and stay open
+	 * having write permissions a proper code will fail and stay open
 	 * (like vim, nano, gedit, geany). However other editors (texmaker
-	 * 5.0.1 and notepadqq 1.0.1) close but despite return 0.
-	 * So we should not check this particular exit code.
+	 * 5.0.1 and notepadqq 1.0.1) close (obviously without saving) but
+	 * despite return 0. So we should not check this particular exit code.
 	 */
 	int unused __attribute__((unused));
 	unused = utils::run_interactively(cmdline, "controller::edit_urls_file");

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -1317,9 +1317,17 @@ void controller::edit_urls_file() {
 	v->push_empty_formaction();
 	stfl::reset();
 
-	utils::run_interactively(cmdline, "controller::edit_urls_file");
+	int editor_exit_code = utils::run_interactively(cmdline, "controller::edit_urls_file");
+	if (editor_exit_code != 0) {
+		LOG(level::DEBUG, "utils::run_interactively: "
+			"The editor failed with error code %d - command was %s", editor_exit_code, cmdline);
+	}
 
 	v->pop_current_formaction();
+
+	if (editor_exit_code != 0) {
+		v->show_error(_("Editor failed to open url file!"));
+	}
 
 	reload_urls_file();
 }

--- a/src/feedlist_formaction.cpp
+++ b/src/feedlist_formaction.cpp
@@ -162,7 +162,9 @@ REDO:
 			if (feed) {
 				if (feed->rssurl().substr(0,6) != "query:") {
 					LOG(level::INFO, "feedlist_formaction: opening feed at position `%s': %s", feedpos, feed->link());
-					v->open_in_browser(feed->link());
+					if (!v->open_in_browser(feed->link()))
+						v->show_error(_("Browser failed to open the link!"));
+
 				} else {
 					v->show_error(_("Cannot open query feeds in the browser!"));
 				}

--- a/src/feedlist_formaction.cpp
+++ b/src/feedlist_formaction.cpp
@@ -162,8 +162,9 @@ REDO:
 			if (feed) {
 				if (feed->rssurl().substr(0,6) != "query:") {
 					LOG(level::INFO, "feedlist_formaction: opening feed at position `%s': %s", feedpos, feed->link());
-					if (!v->open_in_browser(feed->link()))
+					if (!v->open_in_browser(feed->link())) {
 						v->show_error(_("Browser failed to open the link!"));
+					}
 
 				} else {
 					v->show_error(_("Cannot open query feeds in the browser!"));

--- a/src/itemlist_formaction.cpp
+++ b/src/itemlist_formaction.cpp
@@ -84,7 +84,6 @@ void itemlist_formaction::process_operation(operation op, bool automatic, std::v
 		LOG(level::INFO, "itemlist_formaction: opening item at pos `%s'", itemposname);
 		if (itemposname.length() > 0 && visible_items.size() != 0) {
 			if (itempos < visible_items.size()) {
-
 				if (!v->open_in_browser(visible_items[itempos].first->link())) {
 					v->show_error(_("Browser failed to open the link!"));
 					break;
@@ -111,9 +110,9 @@ void itemlist_formaction::process_operation(operation op, bool automatic, std::v
 		LOG(level::INFO, "itemlist_formaction: opening item at pos `%s'", itemposname);
 		if (itemposname.length() > 0 && visible_items.size() != 0) {
 			if (itempos < visible_items.size()) {
-				if (!v->open_in_browser(visible_items[itempos].first->link()))
+				if (!v->open_in_browser(visible_items[itempos].first->link())) {
 					v->show_error(_("Browser failed to open the link!"));
-
+				}
 				invalidate(itempos);
 			}
 		} else {

--- a/src/itemlist_formaction.cpp
+++ b/src/itemlist_formaction.cpp
@@ -85,8 +85,7 @@ void itemlist_formaction::process_operation(operation op, bool automatic, std::v
 		if (itemposname.length() > 0 && visible_items.size() != 0) {
 			if (itempos < visible_items.size()) {
 
-				bool browser_success = v->open_in_browser(visible_items[itempos].first->link());
-				if (!browser_success) {
+				if (!v->open_in_browser(visible_items[itempos].first->link())) {
 					v->show_error(_("Browser failed to open the link!"));
 					break;
 				}
@@ -112,7 +111,9 @@ void itemlist_formaction::process_operation(operation op, bool automatic, std::v
 		LOG(level::INFO, "itemlist_formaction: opening item at pos `%s'", itemposname);
 		if (itemposname.length() > 0 && visible_items.size() != 0) {
 			if (itempos < visible_items.size()) {
-				v->open_in_browser(visible_items[itempos].first->link());
+				if (!v->open_in_browser(visible_items[itempos].first->link()))
+					v->show_error(_("Browser failed to open the link!"));
+
 				invalidate(itempos);
 			}
 		} else {

--- a/src/itemview_formaction.cpp
+++ b/src/itemview_formaction.cpp
@@ -214,7 +214,6 @@ void itemview_formaction::process_operation(operation op, bool automatic, std::v
 		if (!v->open_in_browser(item->link())) {
 			v->show_error(_("Browser failed to open the link!"));
 		}
-		v->set_status("");
 		break;
 	case OP_BOOKMARK:
 		if (automatic) {
@@ -375,7 +374,6 @@ void itemview_formaction::process_operation(operation op, bool automatic, std::v
 			if (!v->open_in_browser(links[idx].first)) {
 				v->show_error(_("Browser failed to open the link!"));
 			}
-			v->set_status("");
 		}
 	}
 	break;
@@ -525,7 +523,6 @@ void itemview_formaction::finished_qna(operation op) {
 			if (!v->open_in_browser(links[idx-1].first)) {
 				v->show_error(_("Browser failed to open the link!"));
 			}
-			v->set_status("");
 		}
 	}
 	break;

--- a/src/itemview_formaction.cpp
+++ b/src/itemview_formaction.cpp
@@ -213,6 +213,8 @@ void itemview_formaction::process_operation(operation op, bool automatic, std::v
 		v->set_status(_("Starting browser..."));
 		if (!v->open_in_browser(item->link())) {
 			v->show_error(_("Browser failed to open the link!"));
+		} else {
+			v->set_status("");
 		}
 		break;
 	case OP_BOOKMARK:
@@ -373,6 +375,8 @@ void itemview_formaction::process_operation(operation op, bool automatic, std::v
 			v->set_status(_("Starting browser..."));
 			if (!v->open_in_browser(links[idx].first)) {
 				v->show_error(_("Browser failed to open the link!"));
+			} else {
+				v->set_status("");
 			}
 		}
 	}
@@ -522,6 +526,8 @@ void itemview_formaction::finished_qna(operation op) {
 			v->set_status(_("Starting browser..."));
 			if (!v->open_in_browser(links[idx-1].first)) {
 				v->show_error(_("Browser failed to open the link!"));
+			} else {
+				v->set_status("");
 			}
 		}
 	}

--- a/src/itemview_formaction.cpp
+++ b/src/itemview_formaction.cpp
@@ -211,7 +211,8 @@ void itemview_formaction::process_operation(operation op, bool automatic, std::v
 	case OP_OPENINBROWSER:
 		LOG(level::INFO, "view::run_itemview: starting browser");
 		v->set_status(_("Starting browser..."));
-		v->open_in_browser(item->link());
+		if (!v->open_in_browser(item->link()))
+			v->show_error(_("Browser failed to open the link!"));
 		v->set_status("");
 		break;
 	case OP_BOOKMARK:
@@ -370,7 +371,8 @@ void itemview_formaction::process_operation(operation op, bool automatic, std::v
 		LOG(level::DEBUG, "itemview::run: OP_1 = %d op = %d idx = %u", OP_1, op, idx);
 		if (idx < links.size()) {
 			v->set_status(_("Starting browser..."));
-			v->open_in_browser(links[idx].first);
+			if (!v->open_in_browser(links[idx].first))
+				v->show_error(_("Browser failed to open the link!"));
 			v->set_status("");
 		}
 	}
@@ -518,7 +520,8 @@ void itemview_formaction::finished_qna(operation op) {
 		sscanf(qna_responses[0].c_str(),"%u",&idx);
 		if (idx && idx-1 < links.size()) {
 			v->set_status(_("Starting browser..."));
-			v->open_in_browser(links[idx-1].first);
+			if (!v->open_in_browser(links[idx-1].first))
+				v->show_error(_("Browser failed to open the link!"));
 			v->set_status("");
 		}
 	}

--- a/src/itemview_formaction.cpp
+++ b/src/itemview_formaction.cpp
@@ -211,8 +211,9 @@ void itemview_formaction::process_operation(operation op, bool automatic, std::v
 	case OP_OPENINBROWSER:
 		LOG(level::INFO, "view::run_itemview: starting browser");
 		v->set_status(_("Starting browser..."));
-		if (!v->open_in_browser(item->link()))
+		if (!v->open_in_browser(item->link())) {
 			v->show_error(_("Browser failed to open the link!"));
+		}
 		v->set_status("");
 		break;
 	case OP_BOOKMARK:
@@ -371,8 +372,9 @@ void itemview_formaction::process_operation(operation op, bool automatic, std::v
 		LOG(level::DEBUG, "itemview::run: OP_1 = %d op = %d idx = %u", OP_1, op, idx);
 		if (idx < links.size()) {
 			v->set_status(_("Starting browser..."));
-			if (!v->open_in_browser(links[idx].first))
+			if (!v->open_in_browser(links[idx].first)) {
 				v->show_error(_("Browser failed to open the link!"));
+			}
 			v->set_status("");
 		}
 	}
@@ -520,8 +522,9 @@ void itemview_formaction::finished_qna(operation op) {
 		sscanf(qna_responses[0].c_str(),"%u",&idx);
 		if (idx && idx-1 < links.size()) {
 			v->set_status(_("Starting browser..."));
-			if (!v->open_in_browser(links[idx-1].first))
+			if (!v->open_in_browser(links[idx-1].first)) {
 				v->show_error(_("Browser failed to open the link!"));
+			}
 			v->set_status("");
 		}
 	}

--- a/src/list_formaction.cpp
+++ b/src/list_formaction.cpp
@@ -12,9 +12,12 @@ void list_formaction::open_unread_items_in_browser(std::shared_ptr<rss_feed> fee
 	for (auto item : feed->items()) {
 		if (tabcount < v->get_cfg()->get_configvalue_as_int("max-browser-tabs")) {
 			if (item->unread()) {
-				v->open_in_browser(item->link());
-				tabcount += 1;
-				item->set_unread(!markread);
+				if (v->open_in_browser(item->link())) {
+					tabcount += 1;
+					item->set_unread(!markread);
+				} else {
+					v->show_error(_("Browser failed to open the link!"));
+				}
 			}
 		} else {
 			break;

--- a/src/pb_controller.cpp
+++ b/src/pb_controller.cpp
@@ -371,9 +371,10 @@ void pb_controller::play_file(const std::string& file) {
 	cmdline.append(utils::replace_all(file,"\"", "\\\""));
 	cmdline.append("\"");
 	stfl::reset();
-	// Is the following exit code important?
-	int unused __attribute__((unused));
-	unused = utils::run_interactively(cmdline, "pb_controller::play_file");
+	int player_exit_code = utils::run_interactively(cmdline, "pb_controller::play_file");
+	if (player_exit_code != 0) {
+		v->dllist_form.set("msg", _("The player failed!"));
+	}
 }
 
 

--- a/src/pb_controller.cpp
+++ b/src/pb_controller.cpp
@@ -371,7 +371,9 @@ void pb_controller::play_file(const std::string& file) {
 	cmdline.append(utils::replace_all(file,"\"", "\\\""));
 	cmdline.append("\"");
 	stfl::reset();
-	utils::run_interactively(cmdline, "pb_controller::play_file");
+	// Is the following exit code important?
+	int unused __attribute__((unused));
+	unused = utils::run_interactively(cmdline, "pb_controller::play_file");
 }
 
 

--- a/src/pb_controller.cpp
+++ b/src/pb_controller.cpp
@@ -361,11 +361,13 @@ void pb_controller::decrease_parallel_downloads() {
 		--max_dls;
 }
 
-void pb_controller::play_file(const std::string& file) {
+bool pb_controller::play_file(const std::string& file) {
 	std::string cmdline;
 	std::string player = cfg->get_configvalue("player");
-	if (player == "")
-		return;
+	if (player == "") {
+		v->show_error(_("No player is set!"));
+		return false;
+	}
 	cmdline.append(player);
 	cmdline.append(" \"");
 	cmdline.append(utils::replace_all(file,"\"", "\\\""));
@@ -373,8 +375,10 @@ void pb_controller::play_file(const std::string& file) {
 	stfl::reset();
 	int player_exit_code = utils::run_interactively(cmdline, "pb_controller::play_file");
 	if (player_exit_code != 0) {
-		v->dllist_form.set("msg", _("The player failed!"));
+		v->show_error(_("The player failed to play the file!"));
+		return false;
 	}
+	return true;
 }
 
 

--- a/src/pb_view.cpp
+++ b/src/pb_view.cpp
@@ -136,8 +136,9 @@ void pb_view::run(bool auto_download) {
 			if (idx != -1) {
 				dlstatus status = ctrl->downloads()[idx].status();
 				if (status == dlstatus::FINISHED || status == dlstatus::PLAYED || status == dlstatus::READY) {
-					ctrl->play_file(ctrl->downloads()[idx].filename());
-					ctrl->downloads()[idx].set_status(dlstatus::PLAYED);
+					if (ctrl->play_file(ctrl->downloads()[idx].filename())) {
+						ctrl->downloads()[idx].set_status(dlstatus::PLAYED);
+					}
 				} else {
 					dllist_form.set("msg", _("Error: download needs to be finished before the file can be played."));
 				}

--- a/src/urlview_formaction.cpp
+++ b/src/urlview_formaction.cpp
@@ -30,8 +30,9 @@ void urlview_formaction::process_operation(operation op, bool /* automatic */, s
 		if (posstr.length() > 0) {
 			unsigned int idx = utils::to_u(posstr, 0);
 			v->set_status(_("Starting browser..."));
-			if (!v->open_in_browser(links[idx].first))
+			if (!v->open_in_browser(links[idx].first)) {
 				v->show_error(_("Browser failed to open the link!"));
+			}
 			v->set_status("");
 		} else {
 			v->show_error(_("No link selected!"));
@@ -64,8 +65,9 @@ void urlview_formaction::process_operation(operation op, bool /* automatic */, s
 
 		if (idx < links.size()) {
 			v->set_status(_("Starting browser..."));
-			if (!v->open_in_browser(links[idx].first))
+			if (!v->open_in_browser(links[idx].first)) {
 				v->show_error(_("Browser failed to open the link!"));
+			}
 			v->set_status("");
 		}
 	}

--- a/src/urlview_formaction.cpp
+++ b/src/urlview_formaction.cpp
@@ -30,7 +30,8 @@ void urlview_formaction::process_operation(operation op, bool /* automatic */, s
 		if (posstr.length() > 0) {
 			unsigned int idx = utils::to_u(posstr, 0);
 			v->set_status(_("Starting browser..."));
-			v->open_in_browser(links[idx].first);
+			if (!v->open_in_browser(links[idx].first))
+				v->show_error(_("Browser failed to open the link!"));
 			v->set_status("");
 		} else {
 			v->show_error(_("No link selected!"));
@@ -63,7 +64,8 @@ void urlview_formaction::process_operation(operation op, bool /* automatic */, s
 
 		if (idx < links.size()) {
 			v->set_status(_("Starting browser..."));
-			v->open_in_browser(links[idx].first);
+			if (!v->open_in_browser(links[idx].first))
+				v->show_error(_("Browser failed to open the link!"));
 			v->set_status("");
 		}
 	}

--- a/src/urlview_formaction.cpp
+++ b/src/urlview_formaction.cpp
@@ -33,7 +33,6 @@ void urlview_formaction::process_operation(operation op, bool /* automatic */, s
 			if (!v->open_in_browser(links[idx].first)) {
 				v->show_error(_("Browser failed to open the link!"));
 			}
-			v->set_status("");
 		} else {
 			v->show_error(_("No link selected!"));
 		}
@@ -68,7 +67,6 @@ void urlview_formaction::process_operation(operation op, bool /* automatic */, s
 			if (!v->open_in_browser(links[idx].first)) {
 				v->show_error(_("Browser failed to open the link!"));
 			}
-			v->set_status("");
 		}
 	}
 	break;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1101,12 +1101,9 @@ int utils::run_interactively(
 		LOG(level::DEBUG, "%s: couldn't create a child process", caller);
 	} else if (status == 127) {
 		LOG(level::DEBUG, "%s: couldn't run shell", caller);
+	} else if (status != 0) {
+		LOG(level::DEBUG, "%s: cmd = %s, returned %d", caller, command, status);
 	}
-	if (status != 0) {
-		LOG(level::DEBUG, "utils::run_interactively: "
-			"%s: cmd = %s, returned %d", caller, command, status);
-	}
-
 
 	return status;
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1102,6 +1102,11 @@ int utils::run_interactively(
 	} else if (status == 127) {
 		LOG(level::DEBUG, "%s: couldn't run shell", caller);
 	}
+	if (status != 0) {
+		LOG(level::DEBUG, "utils::run_interactively: "
+			"%s: cmd = %s, returned %d", caller, command, status);
+	}
+
 
 	return status;
 }

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -333,10 +333,6 @@ bool view::open_in_pager(const std::string& filename) {
 	}
 	stfl::reset();
 	int pager_exit_code = utils::run_interactively(cmdline, "view::open_in_pager");
-	if (pager_exit_code != 0) {
-		LOG(level::DEBUG, "utils::run_interactively: "
-			"Starting the pager failed with error code %d - command was %s", pager_exit_code, cmdline);
-	}
 	pop_current_formaction();
 	return pager_exit_code == 0;
 }
@@ -365,10 +361,6 @@ bool view::open_in_browser(const std::string& url) {
 	}
 	stfl::reset();
 	int browser_exit_code = utils::run_interactively(cmdline, "view::open_in_browser");
-	if (browser_exit_code != 0) {
-		LOG(level::DEBUG, "utils::run_interactively: "
-			"Starting the browser failed with error code %d - command was %s", browser_exit_code, cmdline);
-	}
 	pop_current_formaction();
 
 	return browser_exit_code == 0;

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -311,7 +311,7 @@ void view::push_empty_formaction() {
 	current_formaction = formaction_stack_size() - 1;
 }
 
-void view::open_in_pager(const std::string& filename) {
+bool view::open_in_pager(const std::string& filename) {
 	formaction_stack.push_back(std::shared_ptr<formaction>());
 	current_formaction = formaction_stack_size() - 1;
 	std::string cmdline;
@@ -332,8 +332,13 @@ void view::open_in_pager(const std::string& filename) {
 		cmdline.append(filename);
 	}
 	stfl::reset();
-	utils::run_interactively(cmdline, "view::open_in_pager");
+	int pager_exit_code = utils::run_interactively(cmdline, "view::open_in_pager");
+	if (pager_exit_code != 0) {
+		LOG(level::DEBUG, "utils::run_interactively: "
+			"Starting the pager failed with error code %d - command was %s", pager_exit_code, cmdline);
+	}
 	pop_current_formaction();
+	return pager_exit_code == 0;
 }
 
 bool view::open_in_browser(const std::string& url) {
@@ -480,7 +485,10 @@ void view::push_itemview(std::shared_ptr<rss_feed> f, const std::string& guid, c
 	} else {
 		std::shared_ptr<rss_item> item = f->get_item_by_guid(guid);
 		std::string filename = get_ctrl()->write_temporary_item(item);
-		open_in_pager(filename);
+		if (!open_in_pager(filename)) {
+			show_error(_("Pager failed to show the item!"));
+			return;
+		}
 		try {
 			bool old_unread = item->unread();
 			item->set_unread(false);


### PR DESCRIPTION
newsbeuter utilizes the system(3) function to run external programs.
Examples for external programs are a text editor, an extermal pager or the
browser.
Those external programs may return a non-zero exit code. This patch intercepts
in a such case and prints an error message as well as a debugging output.