### PR TITLE
Tweaks to fix warnings by GCC 8.2.1

### DIFF
--- a/src/oldreader_api.cpp
+++ b/src/oldreader_api.cpp
@@ -134,7 +134,7 @@ std::vector<tagged_feedurl> oldreader_api::get_subscribed_urls() {
 
 			json_object_object_get_ex(sub, "categories", &node);
 			struct array_list * categories = json_object_get_array(node);
-			for (int i = 0; i < array_list_length(categories); i++) {
+			for (unsigned i = 0; i < array_list_length(categories); i++) {
 				json_object* cat = json_object_array_get_idx(node, i);
 				json_object* label_node {};
 				json_object_object_get_ex(cat, "label", &label_node);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1107,7 +1107,7 @@ int utils::run_interactively(
 }
 
 std::string utils::getcwd() {
-	char cwdtmp[MAXPATHLEN];
+	char cwdtmp[MAXPATHLEN+1];
 
 	if (::getcwd(cwdtmp, sizeof(cwdtmp)) == nullptr) {
 		strncpy(cwdtmp, strerror(errno), MAXPATHLEN);


### PR DESCRIPTION
Had to fix these to get the newsbeuter-git package from AUR to build on Arch Linux.